### PR TITLE
fix: muxc:UniformGridLayout crash when navigating to saved recipes & stretch the items correctly

### DIFF
--- a/src/Chefs.UI/Chefs.UI.projitems
+++ b/src/Chefs.UI/Chefs.UI.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)App.xaml.host.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\FixedSizeCardContentControl.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\BoolToObjectConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\CertainNumberToVisible.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Converters\StringSeparatorConverter.cs" />

--- a/src/Chefs.UI/Controls/FixedSizeCardContentControl.cs
+++ b/src/Chefs.UI/Controls/FixedSizeCardContentControl.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Uno.Toolkit.UI;
+using Windows.Foundation;
+
+namespace Chefs.Controls
+{
+    //Using this custom local FixedCardContentControl as a workaround for now regarding this WinUI issue:
+    //https://github.com/unoplatform/uno.chefs/issues/144#issuecomment-1400665013
+    public partial class FixedSizeCardContentControl : CardContentControl
+    {
+        public FixedSizeCardContentControl()
+        {
+            DefaultStyleKey = typeof(CardContentControl);
+        }
+
+        protected override Size MeasureOverride(Size availableSize) => new Size(availableSize.Width, base.MeasureOverride(availableSize).Height);
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            var size = base.ArrangeOverride(finalSize);
+            return size;
+        }
+
+    }
+}

--- a/src/Chefs.UI/Views/SavedRecipesPage.xaml
+++ b/src/Chefs.UI/Views/SavedRecipesPage.xaml
@@ -9,6 +9,7 @@
       xmlns:uer="using:Uno.Extensions.Reactive.UI"
       xmlns:um="using:Uno.Material"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+      xmlns:controls="using:Chefs.Controls"
       x:Name="Root"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -16,27 +17,19 @@
         <ResourceDictionary>
             <DataTemplate x:Key="CookbookTemplate">
                 <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="CookbookTemplateCard.MaxWidth"
-                                            Value="240" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="CookbookTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}"
-                                            uen:Navigation.Request="!SavedCookbookDetail"
-                                            uen:Navigation.Data="{Binding}">
-                        <utu:CardContentControl.ContentTemplate>
+                    <!-- Using a custom local FixedCardContentControl as a workaround for now regarding this WinUI issue: -->
+                    <!-- https://github.com/unoplatform/uno.chefs/issues/144#issuecomment-1400665013 -->
+                    <!-- (For this workaround to be able to work we need to stretch the control and change the MinHeight/MaxWidth values) -->
+                    <controls:FixedSizeCardContentControl x:Name="CookbookTemplateCard"
+                                                          HorizontalAlignment="Stretch"
+                                                          VerticalAlignment="Stretch"
+                                                          MinHeight="0"
+                                                          MaxWidth="500"
+                                                          Style="{StaticResource FilledCardContentControlStyle}"
+                                                          Background="{ThemeResource SurfaceBrush}"
+                                                          uen:Navigation.Request="!SavedCookbookDetail"
+                                                          uen:Navigation.Data="{Binding}">
+                        <controls:FixedSizeCardContentControl.ContentTemplate>
                             <DataTemplate>
                                 <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
                                     <VisualStateManager.VisualStateGroups>
@@ -72,34 +65,26 @@
                                     </utu:AutoLayout>
                                 </utu:AutoLayout>
                             </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
+                        </controls:FixedSizeCardContentControl.ContentTemplate>
+                    </controls:FixedSizeCardContentControl>
                 </utu:AutoLayout>
             </DataTemplate>
 
             <DataTemplate x:Key="RecipeTemplate">
                 <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.MaxWidth"
-                                            Value="240" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}"
-                                            uen:Navigation.Request="!RecipeDetails"
-                                            uen:Navigation.Data="{Binding}">
-                        <utu:CardContentControl.ContentTemplate>
+                    <!-- Using a custom local FixedCardContentControl as a workaround for now regarding this WinUI issue: -->
+                    <!-- https://github.com/unoplatform/uno.chefs/issues/144#issuecomment-1400665013 -->
+                    <!-- (For this workaround to be able to work we need to stretch the control and change the MinHeight/MaxWidth values) -->
+                    <controls:FixedSizeCardContentControl x:Name="RecipeTemplateCard"
+                                                          Style="{StaticResource FilledCardContentControlStyle}"
+                                                          Background="{ThemeResource SurfaceBrush}"
+                                                          HorizontalAlignment="Stretch"
+                                                          VerticalAlignment="Stretch"
+                                                          MinHeight="0"
+                                                          MaxWidth="500"
+                                                          uen:Navigation.Request="!RecipeDetails"
+                                                          uen:Navigation.Data="{Binding}">
+                        <controls:FixedSizeCardContentControl.ContentTemplate>
                             <DataTemplate>
                                 <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
                                     <VisualStateManager.VisualStateGroups>
@@ -135,8 +120,8 @@
                                     </utu:AutoLayout>
                                 </utu:AutoLayout>
                             </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
+                        </controls:FixedSizeCardContentControl.ContentTemplate>
+                    </controls:FixedSizeCardContentControl>
                 </utu:AutoLayout>
             </DataTemplate>
         </ResourceDictionary>
@@ -294,7 +279,8 @@
                                                                     ItemTemplate="{StaticResource RecipeTemplate}">
                                                     <muxc:ItemsRepeater.Layout>
                                                         <muxc:UniformGridLayout MaximumRowsOrColumns="2"
-                                                                                ItemsStretch="Fill" />
+                                                                                ItemsStretch="Fill"
+                                                                                MinItemWidth="248" />
                                                     </muxc:ItemsRepeater.Layout>
                                                 </muxc:ItemsRepeater>
 
@@ -316,7 +302,8 @@
                                                                     ItemTemplate="{StaticResource CookbookTemplate}">
                                                     <muxc:ItemsRepeater.Layout>
                                                         <muxc:UniformGridLayout MaximumRowsOrColumns="2"
-                                                                                ItemsStretch="Fill" />
+                                                                                ItemsStretch="Fill"
+                                                                                MinItemWidth="248" />
                                                     </muxc:ItemsRepeater.Layout>
                                                 </muxc:ItemsRepeater>
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes unoplatform/uno.chefs-archived#643, unoplatform/uno.chefs-archived#612 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

- [Windows] muxc:UniformGridLayout not crashing anymore when navigating to saved recipes
- Saved recipes items are now stretched correctly


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

