### PR TITLE
fix(Windows): Properly use VisualState.StateTriggers inside a DataTemplate by using UserControl

### DIFF
--- a/src/Chefs.UI/Views/CookbookDetailPage.xaml
+++ b/src/Chefs.UI/Views/CookbookDetailPage.xaml
@@ -19,68 +19,72 @@
         <utu:AutoLayout.Resources>
             <x:String x:Key="Icon_Add">F1 M 16 9.142857142857142 L 9.142857142857142 9.142857142857142 L 9.142857142857142 16 L 6.857142857142857 16 L 6.857142857142857 9.142857142857142 L 0 9.142857142857142 L 0 6.857142857142857 L 6.857142857142857 6.857142857142857 L 6.857142857142857 0 L 9.142857142857142 0 L 9.142857142857142 6.857142857142857 L 16 6.857142857142857 L 16 9.142857142857142 Z</x:String>
             <DataTemplate x:Key="RecipeTemplate">
-                <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.MaxWidth"
-                                            Value="200" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}">
-                        <utu:CardContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="140" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="{Binding ImageUrl}"
-                                               Stretch="UniformToFill" />
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                       TextWrapping="NoWrap"
-                                                       Text="{Binding Name}"
-                                                       Style="{StaticResource CustomTitleMedium}" />
-                                            <TextBlock TextWrapping="NoWrap"
-                                                       Text="{Binding TimeCal}"
-                                                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                       Style="{StaticResource CustomCaptionMedium}" />
+                <UserControl>
+                    <utu:AutoLayout>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="RecipeTemplateCard.MaxWidth"
+                                                Value="200" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:CardContentControl x:Name="RecipeTemplateCard"
+                                                MaxWidth="155"
+                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                Background="{ThemeResource SurfaceBrush}">
+                            <utu:CardContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <UserControl>
+                                        <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                    Value="140" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <utu:AutoLayout x:Name="ImageLayout"
+                                                            utu:AutoLayout.PrimaryLength="110">
+                                                <Image Source="{Binding ImageUrl}"
+                                                       Stretch="UniformToFill" />
+                                            </utu:AutoLayout>
+                                            <utu:AutoLayout Spacing="2"
+                                                            Padding="10"
+                                                            PrimaryAxisAlignment="Center"
+                                                            Orientation="Horizontal">
+                                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                               TextWrapping="NoWrap"
+                                                               Text="{Binding Name}"
+                                                               Style="{StaticResource CustomTitleMedium}" />
+                                                    <TextBlock TextWrapping="NoWrap"
+                                                               Text="{Binding TimeCal}"
+                                                               Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                               Style="{StaticResource CustomCaptionMedium}" />
+                                                </utu:AutoLayout>
+                                            </utu:AutoLayout>
                                         </utu:AutoLayout>
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
-                            </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
-                </utu:AutoLayout>
+                                    </UserControl>
+                                </DataTemplate>
+                            </utu:CardContentControl.ContentTemplate>
+                        </utu:CardContentControl>
+                    </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
         </utu:AutoLayout.Resources>
         <VisualStateManager.VisualStateGroups>
@@ -131,39 +135,41 @@
                               utu:AutoLayout.PrimaryAlignment="Stretch">
                     <uer:FeedView Source="{Binding Cookbook}">
                         <DataTemplate>
-                            <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-                                <utu:AutoLayout.Resources>
-                                    <muxc:UniformGridLayout x:Key="NarrowGridLayout"
-                                                            MaximumRowsOrColumns="2"
-                                                            ItemsJustification="SpaceBetween"
-                                                            MinColumnSpacing="10"
-                                                            MinRowSpacing="10"
-                                                            ItemsStretch="Fill" />
-                                    <muxc:UniformGridLayout x:Key="WideGridLayout"
-                                                            MaximumRowsOrColumns="5"
-                                                            MinColumnSpacing="30"
-                                                            MinRowSpacing="30"
-                                                            ItemsStretch="Fill" />
-                                </utu:AutoLayout.Resources>
-                                <VisualStateManager.VisualStateGroups>
-                                    <VisualStateGroup>
-                                        <VisualState x:Name="Narrow" />
-                                        <VisualState x:Name="Wide">
-                                            <VisualState.StateTriggers>
-                                                <AdaptiveTrigger MinWindowWidth="800" />
-                                            </VisualState.StateTriggers>
-                                            <VisualState.Setters>
-                                                <Setter Target="RecipeRepeater.Layout"
-                                                        Value="{StaticResource WideGridLayout}" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                </VisualStateManager.VisualStateGroups>
-                                <muxc:ItemsRepeater x:Name="RecipeRepeater"
-                                                    ItemsSource="{Binding Data.Recipes}"
-                                                    Layout="{StaticResource NarrowGridLayout}"
-                                                    ItemTemplate="{StaticResource RecipeTemplate}" />
-                            </utu:AutoLayout>
+                            <UserControl>
+                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+                                    <utu:AutoLayout.Resources>
+                                        <muxc:UniformGridLayout x:Key="NarrowGridLayout"
+                                                                MaximumRowsOrColumns="2"
+                                                                ItemsJustification="SpaceBetween"
+                                                                MinColumnSpacing="10"
+                                                                MinRowSpacing="10"
+                                                                ItemsStretch="Fill" />
+                                        <muxc:UniformGridLayout x:Key="WideGridLayout"
+                                                                MaximumRowsOrColumns="5"
+                                                                MinColumnSpacing="30"
+                                                                MinRowSpacing="30"
+                                                                ItemsStretch="Fill" />
+                                    </utu:AutoLayout.Resources>
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup>
+                                            <VisualState x:Name="Narrow" />
+                                            <VisualState x:Name="Wide">
+                                                <VisualState.StateTriggers>
+                                                    <AdaptiveTrigger MinWindowWidth="800" />
+                                                </VisualState.StateTriggers>
+                                                <VisualState.Setters>
+                                                    <Setter Target="RecipeRepeater.Layout"
+                                                            Value="{StaticResource WideGridLayout}" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <muxc:ItemsRepeater x:Name="RecipeRepeater"
+                                                        ItemsSource="{Binding Data.Recipes}"
+                                                        Layout="{StaticResource NarrowGridLayout}"
+                                                        ItemTemplate="{StaticResource RecipeTemplate}" />
+                                </utu:AutoLayout>
+                            </UserControl>
                         </DataTemplate>
                     </uer:FeedView>
                 </ScrollViewer>

--- a/src/Chefs.UI/Views/CreateCookbookPage.xaml
+++ b/src/Chefs.UI/Views/CreateCookbookPage.xaml
@@ -30,84 +30,88 @@
             <x:String x:Key="Icon_Outline_Plus_Chefsapp">M 6 12 L 6 0 M 0 5.99999942779541 L 12 6</x:String>
 
             <DataTemplate x:Key="RecipeTemplate">
-                <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.MaxWidth"
-                                            Value="200" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}">
-                        <utu:CardContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="140" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="{Binding ImageUrl}"
-                                               Stretch="UniformToFill" />
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                       TextWrapping="NoWrap"
-                                                       Text="{Binding Name}"
-                                                       Style="{StaticResource CustomTitleMedium}" />
-                                        </utu:AutoLayout>
-                                        <ToggleButton IsChecked="{Binding Selected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      x:Name="toggleButton"
-                                                      Background="{Binding IsChecked, 
+                <UserControl>
+                    <utu:AutoLayout>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="RecipeTemplateCard.MaxWidth"
+                                                Value="200" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:CardContentControl x:Name="RecipeTemplateCard"
+                                                MaxWidth="155"
+                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                Background="{ThemeResource SurfaceBrush}">
+                            <utu:CardContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <UserControl>
+                                        <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                    Value="140" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <utu:AutoLayout x:Name="ImageLayout"
+                                                            utu:AutoLayout.PrimaryLength="110">
+                                                <Image Source="{Binding ImageUrl}"
+                                                       Stretch="UniformToFill" />
+                                            </utu:AutoLayout>
+                                            <utu:AutoLayout Spacing="2"
+                                                            Padding="10"
+                                                            PrimaryAxisAlignment="Center"
+                                                            Orientation="Horizontal">
+                                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                               TextWrapping="NoWrap"
+                                                               Text="{Binding Name}"
+                                                               Style="{StaticResource CustomTitleMedium}" />
+                                                </utu:AutoLayout>
+                                                <ToggleButton IsChecked="{Binding Selected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                              x:Name="toggleButton"
+                                                              Background="{Binding IsChecked, 
                                                                     ElementName=toggleButton, 
                                                                     Converter={StaticResource CustomBackgroundColor}}"
-                                                      utu:AutoLayout.CounterAlignment="Center"
-                                                      Style="{StaticResource IconToggleButtonStyle}"
-                                                      BorderThickness="1"
-                                                      BorderBrush="{ThemeResource PrimaryBrush}"
-                                                      CornerRadius="60"
-                                                      MaxWidth="60">
-                                            <ToggleButton.Content>
-                                                <PathIcon Data="{StaticResource Icon_Add}"
-                                                          Foreground="{ThemeResource SurfaceBrush}" />
-                                            </ToggleButton.Content>
-                                            <um:ControlExtensions.AlternateContent>
-                                                <PathIcon Data="{StaticResource Icon_Check}"
-                                                          Foreground="{ThemeResource PrimaryBrush}" />
-                                            </um:ControlExtensions.AlternateContent>
-                                        </ToggleButton>
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
-                            </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
-                </utu:AutoLayout>
+                                                              utu:AutoLayout.CounterAlignment="Center"
+                                                              Style="{StaticResource IconToggleButtonStyle}"
+                                                              BorderThickness="1"
+                                                              BorderBrush="{ThemeResource PrimaryBrush}"
+                                                              CornerRadius="60"
+                                                              MaxWidth="60">
+                                                    <ToggleButton.Content>
+                                                        <PathIcon Data="{StaticResource Icon_Add}"
+                                                                  Foreground="{ThemeResource SurfaceBrush}" />
+                                                    </ToggleButton.Content>
+                                                    <um:ControlExtensions.AlternateContent>
+                                                        <PathIcon Data="{StaticResource Icon_Check}"
+                                                                  Foreground="{ThemeResource PrimaryBrush}" />
+                                                    </um:ControlExtensions.AlternateContent>
+                                                </ToggleButton>
+                                            </utu:AutoLayout>
+                                        </utu:AutoLayout>
+                                    </UserControl>
+                                </DataTemplate>
+                            </utu:CardContentControl.ContentTemplate>
+                        </utu:CardContentControl>
+                    </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
         </utu:AutoLayout.Resources>
         <VisualStateManager.VisualStateGroups>
@@ -177,39 +181,41 @@
                               utu:AutoLayout.PrimaryAlignment="Stretch">
                     <uer:FeedView Source="{Binding Recipes}">
                         <DataTemplate>
-                            <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-                                <utu:AutoLayout.Resources>
-                                    <muxc:UniformGridLayout x:Key="NarrowGridLayout"
-                                                            MaximumRowsOrColumns="2"
-                                                            ItemsJustification="SpaceBetween"
-                                                            MinColumnSpacing="10"
-                                                            MinRowSpacing="10"
-                                                            ItemsStretch="Fill" />
-                                    <muxc:UniformGridLayout x:Key="WideGridLayout"
-                                                            MaximumRowsOrColumns="5"
-                                                            MinColumnSpacing="30"
-                                                            MinRowSpacing="30"
-                                                            ItemsStretch="Fill" />
-                                </utu:AutoLayout.Resources>
-                                <VisualStateManager.VisualStateGroups>
-                                    <VisualStateGroup>
-                                        <VisualState x:Name="Narrow" />
-                                        <VisualState x:Name="Wide">
-                                            <VisualState.StateTriggers>
-                                                <AdaptiveTrigger MinWindowWidth="800" />
-                                            </VisualState.StateTriggers>
-                                            <VisualState.Setters>
-                                                <Setter Target="RecipeRepeater.Layout"
-                                                        Value="{StaticResource WideGridLayout}" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                </VisualStateManager.VisualStateGroups>
-                                <muxc:ItemsRepeater x:Name="RecipeRepeater"
-                                                    ItemsSource="{Binding Data}"
-                                                    Layout="{StaticResource NarrowGridLayout}"
-                                                    ItemTemplate="{StaticResource RecipeTemplate}" />
-                            </utu:AutoLayout>
+                            <UserControl>
+                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+                                    <utu:AutoLayout.Resources>
+                                        <muxc:UniformGridLayout x:Key="NarrowGridLayout"
+                                                                MaximumRowsOrColumns="2"
+                                                                ItemsJustification="SpaceBetween"
+                                                                MinColumnSpacing="10"
+                                                                MinRowSpacing="10"
+                                                                ItemsStretch="Fill" />
+                                        <muxc:UniformGridLayout x:Key="WideGridLayout"
+                                                                MaximumRowsOrColumns="5"
+                                                                MinColumnSpacing="30"
+                                                                MinRowSpacing="30"
+                                                                ItemsStretch="Fill" />
+                                    </utu:AutoLayout.Resources>
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup>
+                                            <VisualState x:Name="Narrow" />
+                                            <VisualState x:Name="Wide">
+                                                <VisualState.StateTriggers>
+                                                    <AdaptiveTrigger MinWindowWidth="800" />
+                                                </VisualState.StateTriggers>
+                                                <VisualState.Setters>
+                                                    <Setter Target="RecipeRepeater.Layout"
+                                                            Value="{StaticResource WideGridLayout}" />
+                                                </VisualState.Setters>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                    </VisualStateManager.VisualStateGroups>
+                                    <muxc:ItemsRepeater x:Name="RecipeRepeater"
+                                                        ItemsSource="{Binding Data}"
+                                                        Layout="{StaticResource NarrowGridLayout}"
+                                                        ItemTemplate="{StaticResource RecipeTemplate}" />
+                                </utu:AutoLayout>
+                            </UserControl>
                         </DataTemplate>
                     </uer:FeedView>
                 </ScrollViewer>

--- a/src/Chefs.UI/Views/HomePage.xaml
+++ b/src/Chefs.UI/Views/HomePage.xaml
@@ -21,71 +21,73 @@
             <x:String x:Key="Icon_Solid_General_Home">F1 M 9.394394510448079 0.7609653472900391 C 8.411979249516362 -0.2536534070968628 6.784738012754519 -0.25365495681762695 5.802319890799674 0.7609598636627197 L 1.003845277840532 5.71669340133667 C 0.7282613972877743 6.001308917999268 0.5430759234299685 6.361119747161865 0.4716193971961841 6.750794410705566 C -0.11114007932038156 9.928766250610352 -0.1541567839566368 13.182221412658691 0.3443769134629602 16.374488830566406 L 0.520879718566805 17.50469207763672 C 0.5766287211841649 17.861669540405273 0.8840923268096017 18.124845504760742 1.2453989572068052 18.124845504760742 L 4.598359396543396 18.124845504760742 C 4.874502011071342 18.124845504760742 5.098359427921133 17.90098762512207 5.098359427921133 17.624845504760742 L 5.098359427921133 10.624845504760742 L 10.0983597416985 10.624845504760742 L 10.0983597416985 17.624845504760742 C 10.0983597416985 17.90098762512207 10.32221763538548 18.124845504760742 10.598359773076238 18.124845504760742 L 13.951273839996283 18.124845504760742 C 14.312580053160946 18.124845504760742 14.620043718391031 17.861671447753906 14.675793615078119 17.50469207763672 L 14.852295853937804 16.374492645263672 C 15.350829134124861 13.18222427368164 15.307812697709524 9.928764343261719 14.725052803960418 6.750791549682617 C 14.653596843970794 6.361119270324707 14.46841235358969 6.001309871673584 14.192831930106546 5.716695308685303 L 9.394394510448079 0.7609653472900391 Z</x:String>
             <x:String x:Key="Icon_Outline_Alert_ChefsApp">F0 M 8.750068664550781 1.5 C 8.418548107147217 1.5 8.100605964660645 1.6316959261894226 7.866185665130615 1.8661164045333862 C 7.631764888763428 2.1005371809005737 7.500068664550781 2.4184796810150146 7.500068664550781 2.75 C 7.500068664550781 3.0400197505950928 7.332858562469482 3.304046392440796 7.070672512054443 3.4280216693878174 C 6.045307159423828 3.912867546081543 5.171206951141357 4.667598724365234 4.542056083679199 5.611324787139893 C 3.916066884994507 6.550308704376221 3.5560524463653564 7.641171932220459 3.5000689029693604 8.768088340759277 L 3.5000689029693604 11.75 C 3.5000689029693604 11.780123710632324 3.4982540607452393 11.810220718383789 3.494633913040161 11.840126991271973 C 3.405268430709839 12.57840347290039 3.1438052654266357 13.285383224487305 2.7312939167022705 13.904150009155273 C 2.70980167388916 13.93638801574707 2.687930703163147 13.968339920043945 2.665687322616577 14 L 14.834450721740723 14 C 14.812207221984863 13.968339920043945 14.790335655212402 13.93638801574707 14.768843650817871 13.904150009155273 C 14.356332778930664 13.285383224487305 14.094868659973145 12.57840347290039 14.00550365447998 11.840126991271973 C 14.001883506774902 11.810220718383789 14.000068664550781 11.780123710632324 14.000068664550781 11.75 L 14.000068664550781 8.768088340759277 C 13.944085121154785 7.641171932220459 13.584070205688477 6.550308704376221 12.958081245422363 5.611324787139893 C 12.328930854797363 4.667598724365234 11.454830169677734 3.912867546081543 10.429465293884277 3.4280216693878174 C 10.167279243469238 3.304046392440796 10.000068664550781 3.0400197505950928 10.000068664550781 2.75 C 10.000068664550781 2.4184796810150146 9.868372917175293 2.1005371809005737 9.633952140808105 1.8661164045333862 C 9.399531364440918 1.6316959261894226 9.081589698791504 1.5 8.750068664550781 1.5 Z M 11.000068664550781 15.5 L 6.500068664550781 15.5 L 6.500068664550781 15.75 C 6.500068664550781 16.3467378616333 6.73712158203125 16.919034957885742 7.159078121185303 17.34099006652832 C 7.5810346603393555 17.76294708251953 8.153331279754639 18 8.750068664550781 18 C 9.346806526184082 18 9.919102668762207 17.76294708251953 10.341059684753418 17.34099006652832 C 10.763015747070312 16.919034957885742 11.000068664550781 16.3467378616333 11.000068664550781 15.75 L 11.000068664550781 15.5 Z M 5.000068664550781 15.5 L 5.000068664550781 15.75 C 5.000068664550781 16.744561195373535 5.395156383514404 17.698389053344727 6.09841775894165 18.40165138244629 C 6.801679611206055 19.10491180419922 7.755506992340088 19.5 8.750068664550781 19.5 C 9.744629859924316 19.5 10.698457717895508 19.10491180419922 11.401719093322754 18.40165138244629 C 12.104981422424316 17.698389053344727 12.500068664550781 16.744561195373535 12.500068664550781 15.75 L 12.500068664550781 15.5 L 16.75006866455078 15.5 C 17.090686798095703 15.5 17.388532638549805 15.270465850830078 17.475317001342773 14.941088676452637 C 17.562101364135742 14.611711502075195 17.41602897644043 14.265213966369629 17.1196346282959 14.097373008728027 C 16.676871299743652 13.846648216247559 16.29916477203369 13.495467185974121 16.01692008972168 13.072099685668945 C 15.742609024047852 12.66063404083252 15.565917015075684 12.192155838012695 15.500068664550781 11.702418327331543 L 15.500068664550781 8.75 C 15.500068664550781 8.738273620605469 15.499794006347656 8.726549625396729 15.49924373626709 8.714836120605469 C 15.43330192565918 7.309953212738037 14.986303329467773 5.9494948387146 14.206156730651855 4.7792744636535645 C 13.506390571594238 3.7296242713928223 12.562252044677734 2.8685295581817627 11.457574844360352 2.2683637142181396 C 11.359652519226074 1.7179092764854431 11.095362663269043 1.206206738948822 10.694611549377441 0.805456280708313 C 10.178887367248535 0.2897312641143799 9.479413986206055 0 8.750068664550781 0 C 8.020723342895508 0 7.3212504386901855 0.2897312641143799 6.805525302886963 0.805456280708313 C 6.404776096343994 1.206205427646637 6.140486717224121 1.717905879020691 6.042563438415527 2.2683582305908203 C 4.9378862380981445 2.868523955345154 3.9937474727630615 3.7296245098114014 3.293980836868286 4.7792744636535645 C 2.513833999633789 5.9494948387146 2.0668352842330933 7.309953212738037 2.0008935928344727 8.714836120605469 C 2.0003437995910645 8.726549625396729 2.0000689029693604 8.738273620605469 2.0000689029693604 8.75 L 2.0000689029693604 11.702417373657227 C 1.934220314025879 12.192154884338379 1.7575294971466064 12.660633087158203 1.4832183122634888 13.072099685668945 C 1.200973629951477 13.495467185974121 0.8232662677764893 13.846648216247559 0.38050374388694763 14.097373008728027 C 0.08410820364952087 14.265213966369629 -0.06196395866572857 14.611711502075195 0.024820523336529732 14.941088676452637 C 0.11160506494343281 15.270465850830078 0.4094504415988922 15.5 0.7500687837600708 15.5 L 5.000068664550781 15.5 Z</x:String>
             <DataTemplate x:Key="HomeLargeItemTemplate">
-                <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.Margin"
-                                            Value="40,0,0,0" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            utu:AutoLayout.CounterAlignment="Start"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Margin="18,0,0,0"
-                                            MaxWidth="320">
-                        <utu:CardContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <Image Source="{Binding ImageUrl}"
-                                           Stretch="UniformToFill"
-                                           MaxHeight="144" />
-                                    <!-- Additional AutoLayout added here as a workaround for this issue: -->
-                                    <!-- https://github.com/unoplatform/uno.chefs/issues/246 -->
-                                    <utu:AutoLayout Padding="16">
-                                        <utu:AutoLayout Spacing="16"
-                                                        Orientation="Horizontal">
-                                            <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                            utu:AutoLayout.PrimaryAlignment="Stretch">
-                                                <utu:AutoLayout PrimaryAxisAlignment="Center">
-                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                               TextWrapping="Wrap"
-                                                               Text="{Binding Name}"
-                                                               Style="{StaticResource CustomTitleMedium}" />
-                                                    <TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-                                                               TextWrapping="Wrap"
-                                                               Text="{Binding TimeCal}" />
+                <UserControl>
+                    <utu:AutoLayout>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="RecipeTemplateCard.Margin"
+                                                Value="40,0,0,0" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:CardContentControl x:Name="RecipeTemplateCard"
+                                                utu:AutoLayout.CounterAlignment="Start"
+                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                Margin="18,0,0,0"
+                                                MaxWidth="320">
+                            <utu:CardContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                        <Image Source="{Binding ImageUrl}"
+                                               Stretch="UniformToFill"
+                                               MaxHeight="144" />
+                                        <!-- Additional AutoLayout added here as a workaround for this issue: -->
+                                        <!-- https://github.com/unoplatform/uno.chefs/issues/246 -->
+                                        <utu:AutoLayout Padding="16">
+                                            <utu:AutoLayout Spacing="16"
+                                                            Orientation="Horizontal">
+                                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                    <utu:AutoLayout PrimaryAxisAlignment="Center">
+                                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                                   TextWrapping="Wrap"
+                                                                   Text="{Binding Name}"
+                                                                   Style="{StaticResource CustomTitleMedium}" />
+                                                        <TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
+                                                                   TextWrapping="Wrap"
+                                                                   Text="{Binding TimeCal}" />
+                                                    </utu:AutoLayout>
                                                 </utu:AutoLayout>
-                                            </utu:AutoLayout>
-                                            <ToggleButton utu:AutoLayout.CounterAlignment="Center"
-                                                          IsChecked="{Binding Save, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                          Command="{Binding SaveRecipe}"
-                                                          CommandParameter="{Binding}"
-                                                          Style="{StaticResource IconToggleButtonStyle}">
-                                                <ToggleButton.Content>
-                                                    <PathIcon Data="{StaticResource Icon_Outline_Status_Bookmark}"
-                                                              Foreground="{ThemeResource OnBackgroundBrush}" />
-                                                </ToggleButton.Content>
-                                                <um:ControlExtensions.AlternateContent>
+                                                <ToggleButton utu:AutoLayout.CounterAlignment="Center"
+                                                              IsChecked="{Binding Save, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                              Command="{Binding SaveRecipe}"
+                                                              CommandParameter="{Binding}"
+                                                              Style="{StaticResource IconToggleButtonStyle}">
+                                                    <ToggleButton.Content>
+                                                        <PathIcon Data="{StaticResource Icon_Outline_Status_Bookmark}"
+                                                                  Foreground="{ThemeResource OnBackgroundBrush}" />
+                                                    </ToggleButton.Content>
+                                                    <um:ControlExtensions.AlternateContent>
 
-                                                    <PathIcon Data="{StaticResource Icon_Solid_Saved_ChefsApp}"
-                                                              Foreground="{ThemeResource OnBackgroundBrush}" />
-                                                </um:ControlExtensions.AlternateContent>
-                                            </ToggleButton>
+                                                        <PathIcon Data="{StaticResource Icon_Solid_Saved_ChefsApp}"
+                                                                  Foreground="{ThemeResource OnBackgroundBrush}" />
+                                                    </um:ControlExtensions.AlternateContent>
+                                                </ToggleButton>
+                                            </utu:AutoLayout>
                                         </utu:AutoLayout>
                                     </utu:AutoLayout>
-                                </utu:AutoLayout>
-                            </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
-                </utu:AutoLayout>
+                                </DataTemplate>
+                            </utu:CardContentControl.ContentTemplate>
+                        </utu:CardContentControl>
+                    </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
         </utu:AutoLayout.Resources>
 
@@ -325,51 +327,53 @@
                                         </muxc:ItemsRepeater.Layout>
                                         <muxc:ItemsRepeater.ItemTemplate>
                                             <DataTemplate>
-                                                <utu:AutoLayout>
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup>
-                                                            <VisualState x:Name="Narrow" />
-                                                            <VisualState x:Name="Wide">
-                                                                <VisualState.StateTriggers>
-                                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                                </VisualState.StateTriggers>
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="RecentlyAddedTemplateCard.Margin"
-                                                                            Value="40,0,0,0" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-                                                    <utu:CardContentControl x:Name="RecentlyAddedTemplateCard"
-                                                                            utu:AutoLayout.CounterAlignment="Start"
-                                                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                                                            Background="{ThemeResource SurfaceBrush}"
-                                                                            Margin="18, 0, 0, 0"
-                                                                            MaxWidth="171">
-                                                        <utu:CardContentControl.ContentTemplate>
-                                                            <DataTemplate>
-                                                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-                                                                                CornerRadius="12">
-                                                                    <Image Source="{Binding ImageUrl}"
-                                                                           Stretch="UniformToFill"
-                                                                           utu:AutoLayout.PrimaryLength="150" />
-                                                                    <utu:AutoLayout Spacing="2"
-                                                                                    Padding="11, 10"
-                                                                                    PrimaryAxisAlignment="Center">
-                                                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                                                   TextWrapping="NoWrap"
-                                                                                   Text="{Binding Name}"
-                                                                                   Style="{StaticResource CustomTitleMedium}" />
-                                                                        <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                                                   TextWrapping="NoWrap"
-                                                                                   Text="{Binding TimeCal}"
-                                                                                   Style="{StaticResource CustomBodySmall}" />
+                                                <UserControl>
+                                                    <utu:AutoLayout>
+                                                        <VisualStateManager.VisualStateGroups>
+                                                            <VisualStateGroup>
+                                                                <VisualState x:Name="Narrow" />
+                                                                <VisualState x:Name="Wide">
+                                                                    <VisualState.StateTriggers>
+                                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                                    </VisualState.StateTriggers>
+                                                                    <VisualState.Setters>
+                                                                        <Setter Target="RecentlyAddedTemplateCard.Margin"
+                                                                                Value="40,0,0,0" />
+                                                                    </VisualState.Setters>
+                                                                </VisualState>
+                                                            </VisualStateGroup>
+                                                        </VisualStateManager.VisualStateGroups>
+                                                        <utu:CardContentControl x:Name="RecentlyAddedTemplateCard"
+                                                                                utu:AutoLayout.CounterAlignment="Start"
+                                                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                                                Background="{ThemeResource SurfaceBrush}"
+                                                                                Margin="18, 0, 0, 0"
+                                                                                MaxWidth="171">
+                                                            <utu:CardContentControl.ContentTemplate>
+                                                                <DataTemplate>
+                                                                    <utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+                                                                                    CornerRadius="12">
+                                                                        <Image Source="{Binding ImageUrl}"
+                                                                               Stretch="UniformToFill"
+                                                                               utu:AutoLayout.PrimaryLength="150" />
+                                                                        <utu:AutoLayout Spacing="2"
+                                                                                        Padding="11, 10"
+                                                                                        PrimaryAxisAlignment="Center">
+                                                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                                                       TextWrapping="NoWrap"
+                                                                                       Text="{Binding Name}"
+                                                                                       Style="{StaticResource CustomTitleMedium}" />
+                                                                            <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                                                       TextWrapping="NoWrap"
+                                                                                       Text="{Binding TimeCal}"
+                                                                                       Style="{StaticResource CustomBodySmall}" />
+                                                                        </utu:AutoLayout>
                                                                     </utu:AutoLayout>
-                                                                </utu:AutoLayout>
-                                                            </DataTemplate>
-                                                        </utu:CardContentControl.ContentTemplate>
-                                                    </utu:CardContentControl>
-                                                </utu:AutoLayout>
+                                                                </DataTemplate>
+                                                            </utu:CardContentControl.ContentTemplate>
+                                                        </utu:CardContentControl>
+                                                    </utu:AutoLayout>
+                                                </UserControl>
                                             </DataTemplate>
                                         </muxc:ItemsRepeater.ItemTemplate>
                                     </muxc:ItemsRepeater>
@@ -395,44 +399,46 @@
                                         </muxc:ItemsRepeater.Layout>
                                         <muxc:ItemsRepeater.ItemTemplate>
                                             <DataTemplate>
-                                                <utu:AutoLayout Spacing="8"
-                                                                utu:AutoLayout.CounterAlignment="Start">
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup>
-                                                            <VisualState x:Name="Narrow" />
-                                                            <VisualState x:Name="Wide">
-                                                                <VisualState.StateTriggers>
-                                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                                </VisualState.StateTriggers>
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="CreatorsLayout.Height"
-                                                                            Value="124" />
-                                                                    <Setter Target="CreatorsLayout.Width"
-                                                                            Value="124" />
-                                                                    <Setter Target="CreatorsLayout.Margin"
-                                                                            Value="40,0,0,0" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-                                                    <utu:AutoLayout x:Name="CreatorsLayout"
-                                                                    CornerRadius="30"
-                                                                    Orientation="Horizontal"
-                                                                    utu:AutoLayout.CounterAlignment="Center"
-                                                                    Height="75"
-                                                                    Width="75">
-                                                        <Border CornerRadius="25"
-                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
-                                                            <Image Source="{Binding UrlProfileImage}"
-                                                                   Stretch="UniformToFill" />
-                                                        </Border>
+                                                <UserControl>
+                                                    <utu:AutoLayout Spacing="8"
+                                                                    utu:AutoLayout.CounterAlignment="Start">
+                                                        <VisualStateManager.VisualStateGroups>
+                                                            <VisualStateGroup>
+                                                                <VisualState x:Name="Narrow" />
+                                                                <VisualState x:Name="Wide">
+                                                                    <VisualState.StateTriggers>
+                                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                                    </VisualState.StateTriggers>
+                                                                    <VisualState.Setters>
+                                                                        <Setter Target="CreatorsLayout.Height"
+                                                                                Value="124" />
+                                                                        <Setter Target="CreatorsLayout.Width"
+                                                                                Value="124" />
+                                                                        <Setter Target="CreatorsLayout.Margin"
+                                                                                Value="40,0,0,0" />
+                                                                    </VisualState.Setters>
+                                                                </VisualState>
+                                                            </VisualStateGroup>
+                                                        </VisualStateManager.VisualStateGroups>
+                                                        <utu:AutoLayout x:Name="CreatorsLayout"
+                                                                        CornerRadius="30"
+                                                                        Orientation="Horizontal"
+                                                                        utu:AutoLayout.CounterAlignment="Center"
+                                                                        Height="75"
+                                                                        Width="75">
+                                                            <Border CornerRadius="25"
+                                                                    utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                                <Image Source="{Binding UrlProfileImage}"
+                                                                       Stretch="UniformToFill" />
+                                                            </Border>
+                                                        </utu:AutoLayout>
+                                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                                   TextAlignment="Center"
+                                                                   Text="{Binding FullName}"
+                                                                   utu:AutoLayout.CounterAlignment="Center"
+                                                                   Style="{StaticResource CustomBodySmall}" />
                                                     </utu:AutoLayout>
-                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                               TextAlignment="Center"
-                                                               Text="{Binding FullName}"
-                                                               utu:AutoLayout.CounterAlignment="Center"
-                                                               Style="{StaticResource CustomBodySmall}" />
-                                                </utu:AutoLayout>
+                                                </UserControl>
                                             </DataTemplate>
                                         </muxc:ItemsRepeater.ItemTemplate>
                                     </muxc:ItemsRepeater>

--- a/src/Chefs.UI/Views/SavedRecipesPage.xaml
+++ b/src/Chefs.UI/Views/SavedRecipesPage.xaml
@@ -31,39 +31,41 @@
                                                           uen:Navigation.Data="{Binding}">
                         <controls:FixedSizeCardContentControl.ContentTemplate>
                             <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="180" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="ms-appx:///Assets/Recipes/avocado_toast.png"
-                                               Stretch="UniformToFill" />
+                                <UserControl>
+                                    <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="Narrow" />
+                                                <VisualState x:Name="Wide">
+                                                    <VisualState.StateTriggers>
+                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                    </VisualState.StateTriggers>
+                                                    <VisualState.Setters>
+                                                        <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                Value="180" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                        <utu:AutoLayout x:Name="ImageLayout"
+                                                        utu:AutoLayout.PrimaryLength="110">
+                                            <Image Source="ms-appx:///Assets/Recipes/avocado_toast.png"
+                                                   Stretch="UniformToFill" />
+                                        </utu:AutoLayout>
+                                        <utu:AutoLayout Spacing="2"
+                                                        Padding="10"
+                                                        PrimaryAxisAlignment="Center">
+                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                       TextWrapping="NoWrap"
+                                                       Text="{Binding Name}"
+                                                       Style="{StaticResource CustomTitleMedium}" />
+                                            <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                       TextWrapping="NoWrap"
+                                                       Text="{Binding PinsNumber, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} pins'}"
+                                                       Style="{StaticResource CustomBodySmall}" />
+                                        </utu:AutoLayout>
                                     </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center">
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding Name}"
-                                                   Style="{StaticResource CustomTitleMedium}" />
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding PinsNumber, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} pins'}"
-                                                   Style="{StaticResource CustomBodySmall}" />
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
+                                </UserControl>
                             </DataTemplate>
                         </controls:FixedSizeCardContentControl.ContentTemplate>
                     </controls:FixedSizeCardContentControl>
@@ -86,39 +88,41 @@
                                                           uen:Navigation.Data="{Binding}">
                         <controls:FixedSizeCardContentControl.ContentTemplate>
                             <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="180" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="{Binding ImageUrl}"
-                                               Stretch="UniformToFill" />
+                                <UserControl>
+                                    <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="Narrow" />
+                                                <VisualState x:Name="Wide">
+                                                    <VisualState.StateTriggers>
+                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                    </VisualState.StateTriggers>
+                                                    <VisualState.Setters>
+                                                        <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                Value="180" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                        <utu:AutoLayout x:Name="ImageLayout"
+                                                        utu:AutoLayout.PrimaryLength="110">
+                                            <Image Source="{Binding ImageUrl}"
+                                                   Stretch="UniformToFill" />
+                                        </utu:AutoLayout>
+                                        <utu:AutoLayout Spacing="2"
+                                                        Padding="10"
+                                                        PrimaryAxisAlignment="Center">
+                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                       TextWrapping="NoWrap"
+                                                       Text="{Binding Name}"
+                                                       Style="{StaticResource CustomTitleMedium}" />
+                                            <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                       TextWrapping="NoWrap"
+                                                       Text="{Binding TimeCal}"
+                                                       Style="{StaticResource CustomBodySmall}" />
+                                        </utu:AutoLayout>
                                     </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center">
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding Name}"
-                                                   Style="{StaticResource CustomTitleMedium}" />
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding TimeCal}"
-                                                   Style="{StaticResource CustomBodySmall}" />
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
+                                </UserControl>
                             </DataTemplate>
                         </controls:FixedSizeCardContentControl.ContentTemplate>
                     </controls:FixedSizeCardContentControl>

--- a/src/Chefs.UI/Views/SearchPage.xaml
+++ b/src/Chefs.UI/Views/SearchPage.xaml
@@ -21,113 +21,119 @@
             <x:String x:Key="Icon_Outline_Filter_ChefsApp">F0 M 0.02379501610994339 10.804652214050293 C 0.02379501610994339 10.456172853708267 0.2924284040927887 10.173674583435059 0.6238044500350952 10.173674583435059 L 5.664457321166992 10.173674583435059 C 5.9958334267139435 10.173674583435059 6.264466285705566 10.456172853708267 6.264466285705566 10.804652214050293 C 6.264466285705566 11.153131574392319 5.9958334267139435 11.435629844665527 5.664457321166992 11.435629844665527 L 0.6238044500350952 11.435629844665527 C 0.2924284040927887 11.435629844665527 0.02379501610994339 11.153131574392319 0.02379501610994339 10.804652214050293 Z M 7.312614917755127 2.650362014770508 C 7.312614917755127 2.301882654428482 7.581247806549072 2.0193843841552734 7.912623882293701 2.0193843841552734 L 12.953277587890625 2.0193843841552734 C 13.284653753042221 2.0193843841552734 13.5532865524292 2.301882654428482 13.5532865524292 2.650362014770508 C 13.5532865524292 2.9988413751125336 13.284653753042221 3.281339645385742 12.953277587890625 3.281339645385742 L 7.912623882293701 3.281339645385742 C 7.581247806549072 3.281339645385742 7.312614917755127 2.9988413751125336 7.312614917755127 2.650362014770508 Z M 0 2.604888677597046 C 0 1.1621099710464478 1.1192399263381958 0 2.490554094314575 0 C 3.8618680238723755 0 4.98110818862915 1.1621099710464478 4.98110818862915 2.604888677597046 C 4.98110818862915 4.047667384147644 3.8618680238723755 5.209777355194092 2.490554094314575 5.209777355194092 C 1.1192399263381958 5.209777355194092 0 4.047667384147644 0 2.604888677597046 Z M 2.490554094314575 1.2619551420211792 C 1.7738621830940247 1.2619551420211792 1.2000188827514648 1.8675875663757324 1.2000188827514648 2.604888677597046 C 1.2000188827514648 3.3421897292137146 1.7738621830940247 3.947822332382202 2.490554094314575 3.947822332382202 C 3.2072460055351257 3.947822332382202 3.7810895442962646 3.3421897292137146 3.7810895442962646 2.604888677597046 C 3.7810895442962646 1.8675875663757324 3.2072460055351257 1.2619551420211792 2.490554094314575 1.2619551420211792 Z M 9.018891334533691 10.771801948547363 C 9.018891334533691 9.328882217407227 10.138266921043396 8.166913032531738 11.51009750366211 8.166913032531738 C 12.88168215751648 8.166913032531738 14 9.329305648803711 14 10.771801948547363 C 14 12.214298248291016 12.88168215751648 13.376690864562988 11.51009750366211 13.376690864562988 C 10.138266921043396 13.376690864562988 9.018891334533691 12.21472179889679 9.018891334533691 10.771801948547363 Z M 11.51009750366211 9.428868293762207 C 10.792618691921234 9.428868293762207 10.218910217285156 10.034642040729523 10.218910217285156 10.771801948547363 C 10.218910217285156 11.508961975574493 10.792618691921234 12.114736557006836 11.51009750366211 12.114736557006836 C 12.226519227027893 12.114736557006836 12.799980163574219 11.509385466575623 12.799980163574219 10.771801948547363 C 12.799980163574219 10.034218430519104 12.226519227027893 9.428868293762207 11.51009750366211 9.428868293762207 Z</x:String>
             <x:String x:Key="Icon_Outline_Interface_Search">F0 M 10.963515281677246 12.024166107177734 C 8.313246726989746 14.146820068359375 4.433813571929932 13.979755401611328 1.9770290851593018 11.522971153259277 C -0.6590096950531006 8.886931419372559 -0.6590096950531006 4.613068103790283 1.9770290851593018 1.9770293235778809 C 4.613068103790283 -0.6590099334716797 8.886931419372559 -0.6590094566345215 11.522970199584961 1.9770293235778809 C 13.979751586914062 4.433810710906982 14.146820068359375 8.313236236572266 12.024174690246582 10.963505744934082 L 17.179807662963867 16.119138717651367 C 17.472702026367188 16.412031173706055 17.472702026367188 16.886905670166016 17.179807662963867 17.179798126220703 C 16.88691520690918 17.472692489624023 16.41204071044922 17.472692489624023 16.11914825439453 17.179798126220703 L 10.963515281677246 12.024166107177734 Z M 3.037689208984375 10.462310791015625 C 0.9874367713928223 8.412057876586914 0.9874367713928223 5.087942123413086 3.037689208984375 3.037689447402954 C 5.087941646575928 0.9874367713928223 8.412057876586914 0.9874370098114014 10.462310791015625 3.037689447402954 C 12.51105785369873 5.086437225341797 12.512561798095703 8.407177925109863 10.466822624206543 10.457793235778809 C 10.46530818939209 10.459281921386719 10.463798522949219 10.460780143737793 10.46229362487793 10.462285041809082 C 10.46078872680664 10.463789939880371 10.459290504455566 10.465300559997559 10.45780086517334 10.466814994812012 C 8.407186508178711 12.512561798095703 5.08643913269043 12.511059761047363 3.037689208984375 10.462310791015625 Z</x:String>
             <DataTemplate x:Key="EmptyTemplate">
-                <utu:AutoLayout Background="{ThemeResource BackgroundBrush}"
-                                Padding="0,8"
-                                CornerRadius="0,0,0,40">
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="MatchingResultText.Style"
-                                            Value="{StaticResource HeadlineLarge}" />
-                                    <Setter Target="SearchTermsText.Style"
-                                            Value="{StaticResource HeadlineMedium}" />
-                                    <Setter Target="SearchIcon.Style"
-                                            Value="{StaticResource DisplayLarge}" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:AutoLayout Spacing="20"
-                                    Padding="0,150,0,0"
-                                    utu:AutoLayout.PrimaryAlignment="Stretch">
-                        <TextBlock x:Name="SearchIcon"
-                                   TextAlignment="Center"
-                                   Text="🔍"
-                                   utu:AutoLayout.CounterAlignment="Center"
-                                   Foreground="{ThemeResource SurfaceInverseBrush}"
-                                   Style="{StaticResource CustomDisplayMedium}" />
-                        <utu:AutoLayout Spacing="14"
-                                        utu:AutoLayout.CounterAlignment="Center">
-                            <TextBlock x:Name="MatchingResultText"
-                                       Text="No matching search results"
+                <UserControl>
+                    <utu:AutoLayout Background="{ThemeResource BackgroundBrush}"
+                                    Padding="0,8"
+                                    CornerRadius="0,0,0,40">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="MatchingResultText.Style"
+                                                Value="{StaticResource HeadlineLarge}" />
+                                        <Setter Target="SearchTermsText.Style"
+                                                Value="{StaticResource HeadlineMedium}" />
+                                        <Setter Target="SearchIcon.Style"
+                                                Value="{StaticResource DisplayLarge}" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:AutoLayout Spacing="20"
+                                        Padding="0,150,0,0"
+                                        utu:AutoLayout.PrimaryAlignment="Stretch">
+                            <TextBlock x:Name="SearchIcon"
+                                       TextAlignment="Center"
+                                       Text="🔍"
                                        utu:AutoLayout.CounterAlignment="Center"
                                        Foreground="{ThemeResource SurfaceInverseBrush}"
-                                       Style="{StaticResource CustomLabelLarge}" />
-                            <TextBlock x:Name="SearchTermsText"
-                                       Text="Try again using more general search terms"
-                                       utu:AutoLayout.CounterAlignment="Center"
-                                       Foreground="{ThemeResource SurfaceInverseBrush}"
-                                       Style="{StaticResource CustomLabelMedium}" />
+                                       Style="{StaticResource CustomDisplayMedium}" />
+                            <utu:AutoLayout Spacing="14"
+                                            utu:AutoLayout.CounterAlignment="Center">
+                                <TextBlock x:Name="MatchingResultText"
+                                           Text="No matching search results"
+                                           utu:AutoLayout.CounterAlignment="Center"
+                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                           Style="{StaticResource CustomLabelLarge}" />
+                                <TextBlock x:Name="SearchTermsText"
+                                           Text="Try again using more general search terms"
+                                           utu:AutoLayout.CounterAlignment="Center"
+                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                           Style="{StaticResource CustomLabelMedium}" />
+                            </utu:AutoLayout>
                         </utu:AutoLayout>
                     </utu:AutoLayout>
-                </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
             <DataTemplate x:Key="RecipeTemplate">
-                <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.MaxWidth"
-                                            Value="200" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}"
-                                            uen:Navigation.Request="!RecipeDetails"
-                                            uen:Navigation.Data="{Binding}">
-                        <utu:CardContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="140" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="{Binding ImageUrl}"
-                                               Stretch="Uniform" />
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center">
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding Name}"
-                                                   Style="{StaticResource CustomTitleMedium}" />
-                                        <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding TimeCal}"
-                                                   Style="{StaticResource CustomBodySmall}" />
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
-                            </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
-                </utu:AutoLayout>
+                <UserControl>
+                    <utu:AutoLayout>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="RecipeTemplateCard.MaxWidth"
+                                                Value="200" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:CardContentControl x:Name="RecipeTemplateCard"
+                                                MaxWidth="155"
+                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                Background="{ThemeResource SurfaceBrush}"
+                                                uen:Navigation.Request="!RecipeDetails"
+                                                uen:Navigation.Data="{Binding}">
+                            <utu:CardContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <UserControl>
+                                        <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                    Value="140" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <utu:AutoLayout x:Name="ImageLayout"
+                                                            utu:AutoLayout.PrimaryLength="110">
+                                                <Image Source="{Binding ImageUrl}"
+                                                       Stretch="Uniform" />
+                                            </utu:AutoLayout>
+                                            <utu:AutoLayout Spacing="2"
+                                                            Padding="10"
+                                                            PrimaryAxisAlignment="Center">
+                                                <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                           TextWrapping="NoWrap"
+                                                           Text="{Binding Name}"
+                                                           Style="{StaticResource CustomTitleMedium}" />
+                                                <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                           TextWrapping="NoWrap"
+                                                           Text="{Binding TimeCal}"
+                                                           Style="{StaticResource CustomBodySmall}" />
+                                            </utu:AutoLayout>
+                                        </utu:AutoLayout>
+                                    </UserControl>
+                                </DataTemplate>
+                            </utu:CardContentControl.ContentTemplate>
+                        </utu:CardContentControl>
+                    </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
         </utu:AutoLayout.Resources>
         <VisualStateManager.VisualStateGroups>
@@ -143,11 +149,11 @@
                         <Setter Target="RecipesForYouTitle.Style"
                                 Value="{StaticResource CustomHeadlineLarge}" />
                         <Setter Target="RecipesForYouTitle.Margin"
-                                Value="0, 20"  />
+                                Value="0, 20" />
                         <Setter Target="IdeasFromChefsTitle.Style"
                                 Value="{StaticResource CustomHeadlineLarge}" />
                         <Setter Target="IdeasFromChefsTitle.Margin"
-                                Value="0, 20"  />
+                                Value="0, 20" />
                         <Setter Target="RecentSearches.Style"
                                 Value="{StaticResource CustomHeadlineLarge}" />
                         <Setter Target="BackButton.Height"
@@ -255,33 +261,35 @@
                             </muxc:ItemsRepeater.Layout>
                             <muxc:ItemsRepeater.ItemTemplate>
                                 <DataTemplate>
-                                    <utu:AutoLayout>
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup>
-                                                <VisualState x:Name="Narrow" />
-                                                <VisualState x:Name="Wide">
-                                                    <VisualState.StateTriggers>
-                                                        <AdaptiveTrigger MinWindowWidth="800" />
-                                                    </VisualState.StateTriggers>
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SearchHistoryButton.Padding"
-                                                                Value="8,6.5" />
-                                                        <Setter Target="SearchHistoryButton.FontSize"
-                                                                Value="16" />
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <Button Content="{Binding}"
-                                                Padding="5"
-                                                x:Name="SearchHistoryButton"
-                                                Margin="0,0,8,0"
-                                                CornerRadius="8"
-                                                Background="{ThemeResource PrimaryInverseColor}"
-                                                Foreground="{ThemeResource SurfaceColor}"
-                                                Command="{Binding Path=DataContext.ApplySearchHistory, ElementName=HistoryRepeater}"
-                                                CommandParameter="{Binding}" />
-                                    </utu:AutoLayout>
+                                    <UserControl>
+                                        <utu:AutoLayout>
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SearchHistoryButton.Padding"
+                                                                    Value="8,6.5" />
+                                                            <Setter Target="SearchHistoryButton.FontSize"
+                                                                    Value="16" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <Button Content="{Binding}"
+                                                    Padding="5"
+                                                    x:Name="SearchHistoryButton"
+                                                    Margin="0,0,8,0"
+                                                    CornerRadius="8"
+                                                    Background="{ThemeResource PrimaryInverseColor}"
+                                                    Foreground="{ThemeResource SurfaceColor}"
+                                                    Command="{Binding Path=DataContext.ApplySearchHistory, ElementName=HistoryRepeater}"
+                                                    CommandParameter="{Binding}" />
+                                        </utu:AutoLayout>
+                                    </UserControl>
                                 </DataTemplate>
                             </muxc:ItemsRepeater.ItemTemplate>
                         </muxc:ItemsRepeater>
@@ -296,41 +304,43 @@
                                           NoneTemplate="{StaticResource EmptyTemplate}"
                                           Visibility="{Binding Searched}">
                                 <DataTemplate>
-                                    <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-                                        <utu:AutoLayout.Resources>
-                                            <muxc:UniformGridLayout x:Key="NarrowGridLayout"
-                                                                    MaximumRowsOrColumns="2"
-                                                                    ItemsJustification="SpaceBetween"
-                                                                    MinColumnSpacing="10"
-                                                                    MinRowSpacing="10"
-                                                                    ItemsStretch="Fill" />
-                                            <muxc:UniformGridLayout x:Key="WideGridLayout"
-                                                                    MaximumRowsOrColumns="5"
-                                                                    MinColumnSpacing="30"
-                                                                    MinRowSpacing="30"
-                                                                    ItemsStretch="Fill" />
-                                        </utu:AutoLayout.Resources>
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup>
-                                                <VisualState x:Name="Narrow" />
-                                                <VisualState x:Name="Wide">
-                                                    <VisualState.StateTriggers>
-                                                        <AdaptiveTrigger MinWindowWidth="800" />
-                                                    </VisualState.StateTriggers>
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SearchRepeater.Layout"
-                                                                Value="{StaticResource WideGridLayout}" />
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <muxc:ItemsRepeater x:Name="SearchRepeater"
-                                                            ItemsSource="{Binding Data}"
-                                                            uen:Navigation.Request="!RecipeDetails"
-                                                            Layout="{StaticResource NarrowGridLayout}"
-                                                            ItemTemplate="{StaticResource RecipeTemplate}" />
+                                    <UserControl>
+                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+                                            <utu:AutoLayout.Resources>
+                                                <muxc:UniformGridLayout x:Key="NarrowGridLayout"
+                                                                        MaximumRowsOrColumns="2"
+                                                                        ItemsJustification="SpaceBetween"
+                                                                        MinColumnSpacing="10"
+                                                                        MinRowSpacing="10"
+                                                                        ItemsStretch="Fill" />
+                                                <muxc:UniformGridLayout x:Key="WideGridLayout"
+                                                                        MaximumRowsOrColumns="5"
+                                                                        MinColumnSpacing="30"
+                                                                        MinRowSpacing="30"
+                                                                        ItemsStretch="Fill" />
+                                            </utu:AutoLayout.Resources>
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SearchRepeater.Layout"
+                                                                    Value="{StaticResource WideGridLayout}" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <muxc:ItemsRepeater x:Name="SearchRepeater"
+                                                                ItemsSource="{Binding Data}"
+                                                                uen:Navigation.Request="!RecipeDetails"
+                                                                Layout="{StaticResource NarrowGridLayout}"
+                                                                ItemTemplate="{StaticResource RecipeTemplate}" />
 
-                                    </utu:AutoLayout>
+                                        </utu:AutoLayout>
+                                    </UserControl>
                                 </DataTemplate>
                             </uer:FeedView>
                         </ScrollViewer>
@@ -345,77 +355,81 @@
                         <uer:FeedView x:Name="RecommendedFeedView"
                                       Source="{Binding Recommended}">
                             <DataTemplate>
-                                <ScrollViewer HorizontalScrollMode="Enabled"
-                                              HorizontalScrollBarVisibility="Hidden">
-                                    <ScrollViewer.Resources>
-                                        <muxc:StackLayout x:Key="NarrowStackLayout"
-                                                          Orientation="Horizontal"
-                                                          Spacing="8" />
-                                        <muxc:StackLayout x:Key="WideStackLayout"
-                                                          Orientation="Horizontal"
-                                                          Spacing="30" />
-                                    </ScrollViewer.Resources>
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="RecipesForYouRepeater.Layout"
-                                                            Value="{StaticResource WideStackLayout}" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <muxc:ItemsRepeater x:Name="RecipesForYouRepeater"
-                                                        ItemsSource="{Binding Data}"
-                                                        Layout="{StaticResource NarrowStackLayout}">
-                                        <muxc:ItemsRepeater.ItemTemplate>
-                                            <DataTemplate>
-                                                <utu:AutoLayout>
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup>
-                                                            <VisualState x:Name="Narrow" />
-                                                            <VisualState x:Name="Wide">
-                                                                <VisualState.StateTriggers>
-                                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                                </VisualState.StateTriggers>
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="RecipeTemplate.MaxWidth"
-                                                                            Value="200" />
-                                                                    <Setter Target="ImageLayout.MaxHeight"
-                                                                            Value="140" />
-                                                                    <Setter Target="RecipeName.Style"
-                                                                            Value="{StaticResource CustomHeadlineMedium}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-                                                    <utu:AutoLayout x:Name="RecipeTemplate"
-                                                                    Spacing="8"
-                                                                    MaxWidth="105"
-                                                                    uen:Navigation.Request="!RecipeDetails"
-                                                                    uen:Navigation.Data="{Binding}">
-                                                        <Border CornerRadius="12">
-                                                            <Image Source="{Binding ImageUrl}"
-                                                                   Stretch="UniformToFill"
-                                                                   x:Name="ImageLayout"
-                                                                   MaxHeight="80" />
-                                                        </Border>
-                                                        <TextBlock x:Name="RecipeName"
-                                                                   Text="{Binding Name}"
-                                                                   utu:AutoLayout.CounterAlignment="Start"
-                                                                   Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                                   Style="{StaticResource CustomTitleSmall}"
-                                                                   TextWrapping="NoWrap" />
-                                                    </utu:AutoLayout>
-                                                </utu:AutoLayout>
-                                            </DataTemplate>
-                                        </muxc:ItemsRepeater.ItemTemplate>
-                                    </muxc:ItemsRepeater>
-                                </ScrollViewer>
+                                <UserControl>
+                                    <ScrollViewer HorizontalScrollMode="Enabled"
+                                                  HorizontalScrollBarVisibility="Hidden">
+                                        <ScrollViewer.Resources>
+                                            <muxc:StackLayout x:Key="NarrowStackLayout"
+                                                              Orientation="Horizontal"
+                                                              Spacing="8" />
+                                            <muxc:StackLayout x:Key="WideStackLayout"
+                                                              Orientation="Horizontal"
+                                                              Spacing="30" />
+                                        </ScrollViewer.Resources>
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="Narrow" />
+                                                <VisualState x:Name="Wide">
+                                                    <VisualState.StateTriggers>
+                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                    </VisualState.StateTriggers>
+                                                    <VisualState.Setters>
+                                                        <Setter Target="RecipesForYouRepeater.Layout"
+                                                                Value="{StaticResource WideStackLayout}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                        <muxc:ItemsRepeater x:Name="RecipesForYouRepeater"
+                                                            ItemsSource="{Binding Data}"
+                                                            Layout="{StaticResource NarrowStackLayout}">
+                                            <muxc:ItemsRepeater.ItemTemplate>
+                                                <DataTemplate>
+                                                    <UserControl>
+                                                        <utu:AutoLayout>
+                                                            <VisualStateManager.VisualStateGroups>
+                                                                <VisualStateGroup>
+                                                                    <VisualState x:Name="Narrow" />
+                                                                    <VisualState x:Name="Wide">
+                                                                        <VisualState.StateTriggers>
+                                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                                        </VisualState.StateTriggers>
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RecipeTemplate.MaxWidth"
+                                                                                    Value="200" />
+                                                                            <Setter Target="ImageLayout.MaxHeight"
+                                                                                    Value="140" />
+                                                                            <Setter Target="RecipeName.Style"
+                                                                                    Value="{StaticResource CustomHeadlineMedium}" />
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                </VisualStateGroup>
+                                                            </VisualStateManager.VisualStateGroups>
+                                                            <utu:AutoLayout x:Name="RecipeTemplate"
+                                                                            Spacing="8"
+                                                                            MaxWidth="105"
+                                                                            uen:Navigation.Request="!RecipeDetails"
+                                                                            uen:Navigation.Data="{Binding}">
+                                                                <Border CornerRadius="12">
+                                                                    <Image Source="{Binding ImageUrl}"
+                                                                           Stretch="UniformToFill"
+                                                                           x:Name="ImageLayout"
+                                                                           MaxHeight="80" />
+                                                                </Border>
+                                                                <TextBlock x:Name="RecipeName"
+                                                                           Text="{Binding Name}"
+                                                                           utu:AutoLayout.CounterAlignment="Start"
+                                                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                                                           Style="{StaticResource CustomTitleSmall}"
+                                                                           TextWrapping="NoWrap" />
+                                                            </utu:AutoLayout>
+                                                        </utu:AutoLayout>
+                                                    </UserControl>
+                                                </DataTemplate>
+                                            </muxc:ItemsRepeater.ItemTemplate>
+                                        </muxc:ItemsRepeater>
+                                    </ScrollViewer>
+                                </UserControl>
                             </DataTemplate>
                         </uer:FeedView>
                         <TextBlock Text="Ideas from chefs"
@@ -425,77 +439,81 @@
                         <uer:FeedView x:Name="ChefsFeedView"
                                       Source="{Binding FromChefs}">
                             <DataTemplate>
-                                <ScrollViewer HorizontalScrollMode="Enabled"
-                                              HorizontalScrollBarVisibility="Hidden">
-                                    <ScrollViewer.Resources>
-                                        <muxc:StackLayout x:Key="NarrowStackLayout"
-                                                          Orientation="Horizontal"
-                                                          Spacing="8" />
-                                        <muxc:StackLayout x:Key="WideStackLayout"
-                                                          Orientation="Horizontal"
-                                                          Spacing="30" />
-                                    </ScrollViewer.Resources>
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="IdeasFromChefsRecipe.Layout"
-                                                            Value="{StaticResource WideStackLayout}" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <muxc:ItemsRepeater x:Name="IdeasFromChefsRecipe"
-                                                        ItemsSource="{Binding Data}"
-                                                        Layout="{StaticResource NarrowStackLayout}">
-                                        <muxc:ItemsRepeater.ItemTemplate>
-                                            <DataTemplate>
-                                                <utu:AutoLayout>
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup>
-                                                            <VisualState x:Name="Narrow" />
-                                                            <VisualState x:Name="Wide">
-                                                                <VisualState.StateTriggers>
-                                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                                </VisualState.StateTriggers>
-                                                                <VisualState.Setters>
-                                                                    <Setter Target="RecipeTemplate.MaxWidth"
-                                                                            Value="200" />
-                                                                    <Setter Target="ImageLayout.MaxHeight"
-                                                                            Value="140" />
-                                                                    <Setter Target="RecipeName.Style"
-                                                                            Value="{StaticResource CustomHeadlineMedium}" />
-                                                                </VisualState.Setters>
-                                                            </VisualState>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-                                                    <utu:AutoLayout x:Name="RecipeTemplate"
-                                                                    Spacing="8"
-                                                                    MaxWidth="105"
-                                                                    uen:Navigation.Request="!RecipeDetails"
-                                                                    uen:Navigation.Data="{Binding}">
-                                                        <Border CornerRadius="12">
-                                                            <Image Source="{Binding ImageUrl}"
-                                                                   Stretch="UniformToFill"
-                                                                   x:Name="ImageLayout"
-                                                                   MaxHeight="80" />
-                                                        </Border>
-                                                        <TextBlock x:Name="RecipeName"
-                                                                   Text="{Binding Name}"
-                                                                   utu:AutoLayout.CounterAlignment="Start"
-                                                                   Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                                   Style="{StaticResource CustomTitleSmall}"
-                                                                   TextWrapping="NoWrap" />
-                                                    </utu:AutoLayout>
-                                                </utu:AutoLayout>
-                                            </DataTemplate>
-                                        </muxc:ItemsRepeater.ItemTemplate>
-                                    </muxc:ItemsRepeater>
-                                </ScrollViewer>
+                                <UserControl>
+                                    <ScrollViewer HorizontalScrollMode="Enabled"
+                                                  HorizontalScrollBarVisibility="Hidden">
+                                        <ScrollViewer.Resources>
+                                            <muxc:StackLayout x:Key="NarrowStackLayout"
+                                                              Orientation="Horizontal"
+                                                              Spacing="8" />
+                                            <muxc:StackLayout x:Key="WideStackLayout"
+                                                              Orientation="Horizontal"
+                                                              Spacing="30" />
+                                        </ScrollViewer.Resources>
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="Narrow" />
+                                                <VisualState x:Name="Wide">
+                                                    <VisualState.StateTriggers>
+                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                    </VisualState.StateTriggers>
+                                                    <VisualState.Setters>
+                                                        <Setter Target="IdeasFromChefsRecipe.Layout"
+                                                                Value="{StaticResource WideStackLayout}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                        <muxc:ItemsRepeater x:Name="IdeasFromChefsRecipe"
+                                                            ItemsSource="{Binding Data}"
+                                                            Layout="{StaticResource NarrowStackLayout}">
+                                            <muxc:ItemsRepeater.ItemTemplate>
+                                                <DataTemplate>
+                                                    <UserControl>
+                                                        <utu:AutoLayout>
+                                                            <VisualStateManager.VisualStateGroups>
+                                                                <VisualStateGroup>
+                                                                    <VisualState x:Name="Narrow" />
+                                                                    <VisualState x:Name="Wide">
+                                                                        <VisualState.StateTriggers>
+                                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                                        </VisualState.StateTriggers>
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RecipeTemplate.MaxWidth"
+                                                                                    Value="200" />
+                                                                            <Setter Target="ImageLayout.MaxHeight"
+                                                                                    Value="140" />
+                                                                            <Setter Target="RecipeName.Style"
+                                                                                    Value="{StaticResource CustomHeadlineMedium}" />
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                </VisualStateGroup>
+                                                            </VisualStateManager.VisualStateGroups>
+                                                            <utu:AutoLayout x:Name="RecipeTemplate"
+                                                                            Spacing="8"
+                                                                            MaxWidth="105"
+                                                                            uen:Navigation.Request="!RecipeDetails"
+                                                                            uen:Navigation.Data="{Binding}">
+                                                                <Border CornerRadius="12">
+                                                                    <Image Source="{Binding ImageUrl}"
+                                                                           Stretch="UniformToFill"
+                                                                           x:Name="ImageLayout"
+                                                                           MaxHeight="80" />
+                                                                </Border>
+                                                                <TextBlock x:Name="RecipeName"
+                                                                           Text="{Binding Name}"
+                                                                           utu:AutoLayout.CounterAlignment="Start"
+                                                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                                                           Style="{StaticResource CustomTitleSmall}"
+                                                                           TextWrapping="NoWrap" />
+                                                            </utu:AutoLayout>
+                                                        </utu:AutoLayout>
+                                                    </UserControl>
+                                                </DataTemplate>
+                                            </muxc:ItemsRepeater.ItemTemplate>
+                                        </muxc:ItemsRepeater>
+                                    </ScrollViewer>
+                                </UserControl>
                             </DataTemplate>
                         </uer:FeedView>
                     </utu:AutoLayout>

--- a/src/Chefs.UI/Views/UpdateCookbookPage.xaml
+++ b/src/Chefs.UI/Views/UpdateCookbookPage.xaml
@@ -24,84 +24,88 @@
             <x:String x:Key="Icon_Outline_Plus_Chefsapp">M 6 12 L 6 0 M 0 5.99999942779541 L 12 6</x:String>
 
             <DataTemplate x:Key="RecipeTemplate">
-                <utu:AutoLayout>
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="Narrow" />
-                            <VisualState x:Name="Wide">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="RecipeTemplateCard.MaxWidth"
-                                            Value="200" />
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
-                    <utu:CardContentControl x:Name="RecipeTemplateCard"
-                                            MaxWidth="155"
-                                            Style="{StaticResource FilledCardContentControlStyle}"
-                                            Background="{ThemeResource SurfaceBrush}">
-                        <utu:CardContentControl.ContentTemplate>
-                            <DataTemplate>
-                                <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
-                                                            Value="140" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <utu:AutoLayout x:Name="ImageLayout"
-                                                    utu:AutoLayout.PrimaryLength="110">
-                                        <Image Source="{Binding ImageUrl}"
-                                               Stretch="UniformToFill" />
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="2"
-                                                    Padding="10"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                   TextWrapping="NoWrap"
-                                                   Text="{Binding Name}"
-                                                   Style="{StaticResource CustomTitleMedium}" />
-                                        </utu:AutoLayout>
-                                        <ToggleButton IsChecked="{Binding Selected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                  x:Name="toggleButton"
-                                                  Background="{Binding IsChecked, 
+                <UserControl>
+                    <utu:AutoLayout>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="Narrow" />
+                                <VisualState x:Name="Wide">
+                                    <VisualState.StateTriggers>
+                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                    </VisualState.StateTriggers>
+                                    <VisualState.Setters>
+                                        <Setter Target="RecipeTemplateCard.MaxWidth"
+                                                Value="200" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <utu:CardContentControl x:Name="RecipeTemplateCard"
+                                                MaxWidth="155"
+                                                Style="{StaticResource FilledCardContentControlStyle}"
+                                                Background="{ThemeResource SurfaceBrush}">
+                            <utu:CardContentControl.ContentTemplate>
+                                <DataTemplate>
+                                    <UserControl>
+                                        <utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup>
+                                                    <VisualState x:Name="Narrow" />
+                                                    <VisualState x:Name="Wide">
+                                                        <VisualState.StateTriggers>
+                                                            <AdaptiveTrigger MinWindowWidth="800" />
+                                                        </VisualState.StateTriggers>
+                                                        <VisualState.Setters>
+                                                            <Setter Target="ImageLayout.(utu:AutoLayout.PrimaryLength)"
+                                                                    Value="140" />
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                </VisualStateGroup>
+                                            </VisualStateManager.VisualStateGroups>
+                                            <utu:AutoLayout x:Name="ImageLayout"
+                                                            utu:AutoLayout.PrimaryLength="110">
+                                                <Image Source="{Binding ImageUrl}"
+                                                       Stretch="UniformToFill" />
+                                            </utu:AutoLayout>
+                                            <utu:AutoLayout Spacing="2"
+                                                            Padding="10"
+                                                            PrimaryAxisAlignment="Center"
+                                                            Orientation="Horizontal">
+                                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                               TextWrapping="NoWrap"
+                                                               Text="{Binding Name}"
+                                                               Style="{StaticResource CustomTitleMedium}" />
+                                                </utu:AutoLayout>
+                                                <ToggleButton IsChecked="{Binding Selected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                              x:Name="toggleButton"
+                                                              Background="{Binding IsChecked, 
                                                                     ElementName=toggleButton, 
                                                                     Converter={StaticResource CustomBackgroundColor}}"
-                                                  utu:AutoLayout.CounterAlignment="Center"
-                                                  Style="{StaticResource IconToggleButtonStyle}"
-                                                  BorderThickness="1"
-                                                  BorderBrush="{ThemeResource PrimaryBrush}"
-                                                  CornerRadius="60"
-                                                  MaxWidth="60">
-                                            <ToggleButton.Content>
-                                                <PathIcon Data="{StaticResource Icon_Add}"
-                                                      Foreground="{ThemeResource SurfaceBrush}" />
-                                            </ToggleButton.Content>
-                                            <um:ControlExtensions.AlternateContent>
-                                                <PathIcon Data="{StaticResource Icon_Check}"
-                                                      Foreground="{ThemeResource PrimaryBrush}" />
-                                            </um:ControlExtensions.AlternateContent>
-                                        </ToggleButton>
-                                    </utu:AutoLayout>
-                                </utu:AutoLayout>
-                            </DataTemplate>
-                        </utu:CardContentControl.ContentTemplate>
-                    </utu:CardContentControl>
-                </utu:AutoLayout>
+                                                              utu:AutoLayout.CounterAlignment="Center"
+                                                              Style="{StaticResource IconToggleButtonStyle}"
+                                                              BorderThickness="1"
+                                                              BorderBrush="{ThemeResource PrimaryBrush}"
+                                                              CornerRadius="60"
+                                                              MaxWidth="60">
+                                                    <ToggleButton.Content>
+                                                        <PathIcon Data="{StaticResource Icon_Add}"
+                                                                  Foreground="{ThemeResource SurfaceBrush}" />
+                                                    </ToggleButton.Content>
+                                                    <um:ControlExtensions.AlternateContent>
+                                                        <PathIcon Data="{StaticResource Icon_Check}"
+                                                                  Foreground="{ThemeResource PrimaryBrush}" />
+                                                    </um:ControlExtensions.AlternateContent>
+                                                </ToggleButton>
+                                            </utu:AutoLayout>
+                                        </utu:AutoLayout>
+                                    </UserControl>
+                                </DataTemplate>
+                            </utu:CardContentControl.ContentTemplate>
+                        </utu:CardContentControl>
+                    </utu:AutoLayout>
+                </UserControl>
             </DataTemplate>
         </utu:AutoLayout.Resources>
         <VisualStateManager.VisualStateGroups>
@@ -161,40 +165,42 @@
                 <ScrollViewer HorizontalScrollMode="Disabled"
                               VerticalScrollBarVisibility="Hidden"
                               utu:AutoLayout.PrimaryAlignment="Stretch">
-                    <utu:AutoLayout >
+                    <utu:AutoLayout>
                         <uer:FeedView Source="{Binding Recipes}">
                             <DataTemplate>
-                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
-                                    <utu:AutoLayout.Resources>
-                                        <muxc:UniformGridLayout x:Key="NarrowGridLayout"
-                                                                MaximumRowsOrColumns="2"
-                                                                ItemsJustification="SpaceBetween"
-                                                                MinColumnSpacing="10"
-                                                                MinRowSpacing="10"
-                                                                ItemsStretch="Fill" />
-                                        <muxc:UniformGridLayout x:Key="WideGridLayout"
-                                                                MaximumRowsOrColumns="5"
-                                                                ItemsStretch="Fill" />
-                                    </utu:AutoLayout.Resources>
-                                    <VisualStateManager.VisualStateGroups>
-                                        <VisualStateGroup>
-                                            <VisualState x:Name="Narrow" />
-                                            <VisualState x:Name="Wide">
-                                                <VisualState.StateTriggers>
-                                                    <AdaptiveTrigger MinWindowWidth="800" />
-                                                </VisualState.StateTriggers>
-                                                <VisualState.Setters>
-                                                    <Setter Target="RecipeRepeater.Layout"
-                                                        Value="{StaticResource WideGridLayout}" />
-                                                </VisualState.Setters>
-                                            </VisualState>
-                                        </VisualStateGroup>
-                                    </VisualStateManager.VisualStateGroups>
-                                    <muxc:ItemsRepeater x:Name="RecipeRepeater"
-                                                        ItemsSource="{Binding Data}"
-                                                        Layout="{StaticResource NarrowGridLayout}"
-                                                        ItemTemplate="{StaticResource RecipeTemplate}" />
-                                </utu:AutoLayout>
+                                <UserControl>
+                                    <utu:AutoLayout utu:AutoLayout.CounterAlignment="Stretch">
+                                        <utu:AutoLayout.Resources>
+                                            <muxc:UniformGridLayout x:Key="NarrowGridLayout"
+                                                                    MaximumRowsOrColumns="2"
+                                                                    ItemsJustification="SpaceBetween"
+                                                                    MinColumnSpacing="10"
+                                                                    MinRowSpacing="10"
+                                                                    ItemsStretch="Fill" />
+                                            <muxc:UniformGridLayout x:Key="WideGridLayout"
+                                                                    MaximumRowsOrColumns="5"
+                                                                    ItemsStretch="Fill" />
+                                        </utu:AutoLayout.Resources>
+                                        <VisualStateManager.VisualStateGroups>
+                                            <VisualStateGroup>
+                                                <VisualState x:Name="Narrow" />
+                                                <VisualState x:Name="Wide">
+                                                    <VisualState.StateTriggers>
+                                                        <AdaptiveTrigger MinWindowWidth="800" />
+                                                    </VisualState.StateTriggers>
+                                                    <VisualState.Setters>
+                                                        <Setter Target="RecipeRepeater.Layout"
+                                                                Value="{StaticResource WideGridLayout}" />
+                                                    </VisualState.Setters>
+                                                </VisualState>
+                                            </VisualStateGroup>
+                                        </VisualStateManager.VisualStateGroups>
+                                        <muxc:ItemsRepeater x:Name="RecipeRepeater"
+                                                            ItemsSource="{Binding Data}"
+                                                            Layout="{StaticResource NarrowGridLayout}"
+                                                            ItemTemplate="{StaticResource RecipeTemplate}" />
+                                    </utu:AutoLayout>
+                                </UserControl>
                             </DataTemplate>
                         </uer:FeedView>
                     </utu:AutoLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): closes https://github.com/unoplatform/uno.chefs-archived/issues/554, https://github.com/unoplatform/uno.chefs-archived/issues/553

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

VisualState.StateTriggers are not working inside a DataTemplate for Windows


## What is the new behavior?

Properly use VisualState.StateTriggers inside a DataTemplate by using UserControl for Windows


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
