### PR TITLE
fix: Workaround to display Saved Recipes and Cookbooks with latest packages

### DIFF
--- a/src/Chefs.Mobile/Chefs.Mobile.csproj
+++ b/src/Chefs.Mobile/Chefs.Mobile.csproj
@@ -29,8 +29,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.1038" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.1038" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">
@@ -80,7 +80,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
+++ b/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
@@ -23,8 +23,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.0-dev.1038" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.1038" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -34,7 +34,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
+++ b/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
@@ -16,8 +16,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.0-dev.1038" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.1038" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -27,7 +27,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
+++ b/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.0-dev.1038" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.1038" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -33,6 +33,6 @@
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
       <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	  <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 </Project>

--- a/src/Chefs.Tests/Chefs.Tests.csproj
+++ b/src/Chefs.Tests/Chefs.Tests.csproj
@@ -24,6 +24,6 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 </Project>

--- a/src/Chefs.UI/Views/SavedRecipesPage.xaml
+++ b/src/Chefs.UI/Views/SavedRecipesPage.xaml
@@ -166,6 +166,14 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
+
+        <!-- Workaround for the https://github.com/unoplatform/uno.chefs/issues/292 issue & https://github.com/unoplatform/uno.extensions/issues/1161 -->
+        <!-- To Force the Feedview Binding to work correctly in order to show the saved items for Recipes and CookBooks -->
+        <TextBlock Text="{Binding SavedRecipes.Count}"
+                   Visibility="Collapsed" />
+        <TextBlock Text="{Binding SavedCookbooks.Count}"
+                   Visibility="Collapsed" />
+
         <utu:AutoLayout x:Name="ContentLayout"
                         utu:AutoLayout.PrimaryAlignment="Stretch"
                         Padding="18">
@@ -204,7 +212,8 @@
                             <utu:AutoLayout Visibility="Visible"
                                             utu:AutoLayout.CounterAlignment="Center"
                                             uen:Region.Name="MyRecipes">
-                                <uer:FeedView Source="{Binding Recipes}">
+
+                                <uer:FeedView Source="{Binding SavedRecipes}">
                                     <DataTemplate>
                                         <muxc:ItemsRepeater ItemsSource="{Binding Data}"
                                                             ItemTemplate="{StaticResource RecipeTemplate}">
@@ -220,7 +229,7 @@
                             </utu:AutoLayout>
                             <utu:AutoLayout Visibility="Collapsed"
                                             uen:Region.Name="Cookbooks">
-                                <uer:FeedView Source="{Binding Cookbooks}">
+                                <uer:FeedView Source="{Binding SavedCookbooks}">
                                     <DataTemplate>
                                         <muxc:ItemsRepeater ItemsSource="{Binding Data}"
                                                             ItemTemplate="{StaticResource CookbookTemplate}">
@@ -256,7 +265,7 @@
                                           VerticalScrollBarVisibility="Hidden">
                                 <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
                                     <utu:AutoLayout>
-                                        <uer:FeedView Source="{Binding Recipes}">
+                                        <uer:FeedView Source="{Binding SavedRecipes}">
                                             <DataTemplate>
                                                 <muxc:ItemsRepeater ItemsSource="{Binding Data}"
                                                                     ItemTemplate="{StaticResource RecipeTemplate}">
@@ -288,7 +297,7 @@
                                           VerticalScrollBarVisibility="Hidden">
                                 <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
                                     <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
-                                        <uer:FeedView Source="{Binding Cookbooks}">
+                                        <uer:FeedView Source="{Binding SavedCookbooks}">
                                             <DataTemplate>
                                                 <muxc:ItemsRepeater ItemsSource="{Binding Data}"
                                                                     ItemTemplate="{StaticResource CookbookTemplate}">

--- a/src/Chefs.UITests/Chefs.UITests.csproj
+++ b/src/Chefs.UITests/Chefs.UITests.csproj
@@ -40,7 +40,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 
 </Project>

--- a/src/Chefs.Wasm/Chefs.Wasm.csproj
+++ b/src/Chefs.Wasm/Chefs.Wasm.csproj
@@ -51,8 +51,8 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.0-dev.1038" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.0-dev.1038" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.7.37" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.7.37" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.8" />
 	</ItemGroup>
@@ -62,7 +62,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" Condition="Exists('..\Chefs.UI\Chefs.UI.projitems')" />

--- a/src/Chefs.Windows/Chefs.Windows.csproj
+++ b/src/Chefs.Windows/Chefs.Windows.csproj
@@ -61,7 +61,7 @@
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.7.0-dev.1038" />
+		<PackageReference Include="Uno.WinUI" Version="4.7.37" />
 	</ItemGroup>
 
 	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
@@ -90,7 +90,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs/Chefs.csproj
+++ b/src/Chefs/Chefs.csproj
@@ -9,6 +9,6 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 	</ItemGroup>
 </Project>

--- a/src/Chefs/Presentation/SavedRecipesModel.cs
+++ b/src/Chefs/Presentation/SavedRecipesModel.cs
@@ -18,7 +18,8 @@ public partial class SavedRecipesModel
         _cookbookService = cookbookService;
     }
 
-    public IListFeed<Cookbook> Cookbooks => _cookbookService.SavedCookbooks;
+    public IListFeed<Cookbook> SavedCookbooks => _cookbookService.SavedCookbooks;
 
-    public IListFeed<Recipe> Recipes => _recipeService.SavedRecipes;
+    public IListFeed<Recipe> SavedRecipes => _recipeService.SavedRecipes;
+
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.0-dev.1038" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.7.37" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
 	</ItemGroup>
 </Project>

--- a/src/Extensions.props
+++ b/src/Extensions.props
@@ -2,23 +2,23 @@
   <ItemGroup>
     <!--<PackageReference Include="Uno.Extensions.Authentication" Version="255.255.255.255" />
     <PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="255.255.255.255" />-->
-	<PackageReference Include="Uno.Extensions.Configuration" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Core" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Hosting" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Http" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Http.Refit" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Navigation" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Serialization" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Serialization.Http" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Reactive" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="2.3.0-dev.513" />
-	<PackageReference Include="Uno.Extensions.Reactive.Messaging" Version="2.3.0-dev.513" />
+	<PackageReference Include="Uno.Extensions.Configuration" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Core" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Hosting" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Http" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Http.Refit" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Navigation" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Serialization" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Serialization.Http" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Reactive" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="2.3.0-dev.662" />
+	<PackageReference Include="Uno.Extensions.Reactive.Messaging" Version="2.3.0-dev.662" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#555

## PR Type

What kind of change does this PR introduce?

- Bugfix with a workaround


## Description
Workaround to display Saved Recipes and Cookbooks with latest packages


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
