### PR TITLE
fix(Android): Recipes and Cookbooks not visible for the ProfileDetailsPage

### DIFF
--- a/src/Chefs.UI/Views/ProfileDetailsPage.xaml
+++ b/src/Chefs.UI/Views/ProfileDetailsPage.xaml
@@ -144,6 +144,14 @@
                         utu:AutoLayout.PrimaryAlignment="Stretch"
                         utu:AutoLayout.CounterAlignment="Stretch"
                         uen:Region.Attached="True">
+
+            <!-- Workaround for the https://github.com/unoplatform/uno.chefs/issues/292 issue & https://github.com/unoplatform/uno.extensions/issues/1161 -->
+            <!-- To Force the Feedview Binding to work correctly in order to show the items for Recipes and CookBooks -->
+            <TextBlock Text="{Binding Recipes.Count}"
+                       Visibility="Collapsed" />
+            <TextBlock Text="{Binding Cookbooks.Count}"
+                       Visibility="Collapsed" />
+            
             <utu:AutoLayout x:Name="NavBarLayout"
                             Background="{ThemeResource SurfaceBrush}">
                 <utu:NavigationBar x:Name="PhoneNavBar"

--- a/src/Chefs.UI/Views/SearchPage.xaml
+++ b/src/Chefs.UI/Views/SearchPage.xaml
@@ -497,8 +497,9 @@
                             </DataTemplate>
                         </uer:FeedView>
                     </utu:AutoLayout>
+                    
                     <!-- Workaround for the https://github.com/unoplatform/uno.chefs/issues/292 issue & https://github.com/unoplatform/uno.extensions/issues/1161 -->
-                    <!-- To Force the Feedview Binding to work correctly in order to show the saved items for Recommended and FromChefs -->
+                    <!-- To Force the Feedview Binding to work correctly in order to show the items for Recommended and FromChefs -->
                     <TextBlock Text="{Binding Recommended.Count}"
                                Visibility="Collapsed" />
                     <TextBlock Text="{Binding FromChefs.Count}"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#546, unoplatform/uno.chefs-archived#555

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix [Android]: Recipes and Cookbooks not visible for the ProfileDetailsPage

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
