### PR TITLE
fix: Multiple Binding and Navigation issues

### DIFF
--- a/src/Chefs.UI/App.xaml.host.cs
+++ b/src/Chefs.UI/App.xaml.host.cs
@@ -73,7 +73,7 @@ public static class AppHost
             new ViewMap<HomePage, HomeModel>(),
             new ViewMap<IngredientsPage, IngredientsModel>(Data: new DataMap<IngredientsParameter>()),
             new ViewMap<CreateCookbookPage, CreateCookbookModel>(),
-            new DataViewMap<UpdateCookbookPage, UpdateCookbookModel, Cookbook>(),
+            new DataViewMap<UpdateCookbookPage, UpdateCookbookModel, UpdateCookbook>(),
             new ViewMap<LoginPage, LoginModel>(ResultData: typeof(Credentials)),
             new ViewMap<NotificationsPage>(),
             new ViewMap<NotificationsContentPage, NotificationsModel>(),

--- a/src/Chefs.UI/Views/HomePage.xaml
+++ b/src/Chefs.UI/Views/HomePage.xaml
@@ -72,7 +72,7 @@
                                             </utu:AutoLayout>
                                             <ToggleButton utu:AutoLayout.CounterAlignment="Center"
                                                           IsChecked="{Binding Save, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                          Command="{Binding SaveRecipe}"
+                                                          Command="{utu:AncestorBinding AncestorType=uer:FeedView, Path=DataContext.SaveRecipe}"
                                                           CommandParameter="{Binding}"
                                                           Style="{StaticResource IconToggleButtonStyle}">
                                                 <ToggleButton.Content>

--- a/src/Chefs.UI/Views/LoginPage.xaml
+++ b/src/Chefs.UI/Views/LoginPage.xaml
@@ -129,7 +129,7 @@
                                         utu:AutoLayout.CounterAlignment="Stretch"
                                         Orientation="Horizontal">
                             <CheckBox Content="Remember me"
-                                      IsChecked="{Binding AuthOptions.SaveCredentials, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      IsChecked="{Binding Credentials.SaveCredentials, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       utu:AutoLayout.CounterAlignment="Center"
                                       utu:AutoLayout.PrimaryAlignment="Stretch" />
                             <TextBlock Text="Forgot password?"
@@ -245,7 +245,7 @@
                                         utu:AutoLayout.PrimaryAlignment="Stretch"
                                         Orientation="Horizontal">
                             <CheckBox Content="Remember me"
-                                      IsChecked="{Binding AuthOptions.SaveCredentials, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                      IsChecked="{Binding Credentials.SaveCredentials, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                       utu:AutoLayout.CounterAlignment="Center"
                                       utu:AutoLayout.PrimaryAlignment="Stretch" />
                             <TextBlock Text="Forgot password?"

--- a/src/Chefs.UI/Views/MainPage.xaml
+++ b/src/Chefs.UI/Views/MainPage.xaml
@@ -104,19 +104,17 @@
                             Background="{ThemeResource SurfaceBrush}"
                             Visibility="Collapsed"
                             Width="120">
-                <utu:AutoLayout PrimaryAxisAlignment="Center"
-                                Margin="0,40"
-                                uen:Navigation.Request="!Profile"
-								uen:Navigation.Data="{Binding ProfileResponse, Mode=TwoWay}">
-                    <Border utu:AutoLayout.IsIndependentLayout="True"
-                            utu:AutoLayout.CounterAlignment="Center"
-                            Width="56"
-                            Height="56"
-                            CornerRadius="15">
+                <Button Command="{Binding ShowProfile}"
+                        Width="56"
+                        Height="56"
+                        Margin="0,40"
+                        utu:AutoLayout.CounterAlignment="Center"
+                        Style="{StaticResource IconButtonStyle}">
+                    <Border CornerRadius="15">
                         <Image Source="{Binding UserProfile.UrlProfileImage}"
                                Stretch="UniformToFill" />
                     </Border>
-                </utu:AutoLayout>
+                </Button>
                 <utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
                     <utu:TabBar uen:Region.Attached="True"
                                 Style="{StaticResource VerticalTabBarStyle}"

--- a/src/Chefs.UI/Views/ProfileDetailsPage.xaml
+++ b/src/Chefs.UI/Views/ProfileDetailsPage.xaml
@@ -589,10 +589,10 @@
                                                                                                             </utu:AutoLayout>
                                                                                                             <utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch"
                                                                                                                             utu:AutoLayout.CounterAlignment="Stretch"
-                                                                                                                            Visibility="{Binding CookbookImages.ThirdImage,
-                                                                                                                                    Converter={StaticResource  NullToVisible}}">
-                                                                                                                <Button uen:Navigation.Request="CreateUpdateCookbook"
-                                                                                                                        uen:Navigation.Data="{Binding ., Mode=TwoWay }"
+                                                                                                                            Visibility="{Binding CookbookImages.ThirdImage, 
+                                                                                                                                   Converter={StaticResource NullToVisible}}">
+                                                                                                                <Button Command="{utu:AncestorBinding AncestorType=uer:FeedView, Path=DataContext.UpdateCookBookNavigation}"
+                                                                                                                        CommandParameter="{Binding}"
                                                                                                                         Background="{ThemeResource SurfaceVariantColor}"
                                                                                                                         utu:AutoLayout.CounterAlignment="Stretch"
                                                                                                                         utu:AutoLayout.PrimaryAlignment="Stretch"
@@ -622,8 +622,8 @@
                                                                                                     <TextBlock Foreground="{ThemeResource OnSurfaceVariantBrush}"
                                                                                                                TextWrapping="NoWrap"
                                                                                                                Text="{Binding PinsNumber, 
-                                                                                                                Converter={StaticResource StringFormatter}, 
-                                                                                                                ConverterParameter='{}{0} pins'}"
+                                                                                                                   Converter={StaticResource StringFormatter}, 
+                                                                                                                   ConverterParameter='{}{0} pins'}"
                                                                                                                Style="{StaticResource BodySmall}" />
                                                                                                 </utu:AutoLayout>
                                                                                             </utu:AutoLayout>
@@ -650,7 +650,8 @@
                                             VerticalAlignment="Bottom"
                                             HorizontalAlignment="Right"
                                             Margin="0,18">
-                                <Button uen:Navigation.Request="!ModalCreateCookbook"
+                                <Button uen:Navigation.Request="-"
+                                        uen:Navigation.Data="{Binding EmptyCookBook}"
                                         utu:AutoLayout.CounterAlignment="End"
                                         CornerRadius="60"
                                         Style="{StaticResource FabStyle}">

--- a/src/Chefs.UI/Views/SearchPage.xaml
+++ b/src/Chefs.UI/Views/SearchPage.xaml
@@ -303,7 +303,7 @@
                                                     CornerRadius="8"
                                                     Background="{ThemeResource PrimaryInverseColor}"
                                                     Foreground="{ThemeResource SurfaceColor}"
-                                                    Command="{Binding Path=DataContext.ApplySearchHistory, ElementName=HistoryRepeater}"
+                                                    Command="{utu:AncestorBinding AncestorType=muxc:ItemsRepeater, Path=DataContext.ApplySearchHistory}"
                                                     CommandParameter="{Binding}" />
                                         </utu:AutoLayout>
                                     </UserControl>

--- a/src/Chefs/Business/Models/Cookbook.cs
+++ b/src/Chefs/Business/Models/Cookbook.cs
@@ -46,6 +46,8 @@ public partial record Cookbook : IChefEntity
                 .ToList()
             : recipes
                 .Select(c => c.ToData())
-                .ToList()      
+                .ToList()
     };
+
+    internal UpdateCookbook UpdateCookBook() => new(this);
 }

--- a/src/Chefs/Business/Models/UpdateCookBook.cs
+++ b/src/Chefs/Business/Models/UpdateCookBook.cs
@@ -1,0 +1,3 @@
+﻿namespace Chefs.Business;
+
+public partial record UpdateCookbook(Cookbook Cookbook) : IChefEntity;

--- a/src/Chefs/Presentation/MainModel.cs
+++ b/src/Chefs/Presentation/MainModel.cs
@@ -10,28 +10,30 @@ public partial class MainModel
 
     private readonly INavigator _navigator;
 
-	public MainModel(
+    public MainModel(
         IUserService userService,
-		IOptions<AppConfig> appInfo, 
+        IOptions<AppConfig> appInfo,
         INavigator navigator)
-	{ 
+    {
         Title = $"Main - {appInfo?.Value?.Title ?? "Chefs"}";
         _navigator = navigator;
         _userService = userService;
-
-        ProfileResponse = State<IChefEntity>.Empty(this);
-        ProfileResponse.ForEachAsync(async (obj, ct) =>
-        {
-            if (obj is not null && 
-            obj.GetType() != typeof(object))
-            {
-                await _navigator.NavigateDataAsync(this, obj, qualifier:Qualifiers.Nested);
-            }
-        });
     }
 
-    public IState<IChefEntity> ProfileResponse { get; }
+    public async Task ShowProfile()
+    {
+        var response = await _navigator.NavigateRouteForResultAsync<IChefEntity>(this, "Profile", qualifier: Qualifiers.Dialog);
+        var result = await response!.Result;
 
+        await (result.SomeOrDefault() switch
+        {
+            UpdateCookbook updateCookbook => _navigator.NavigateViewModelAsync<UpdateCookbookModel>(this, data: updateCookbook.Cookbook, qualifier: Qualifiers.Nested),
+            Cookbook cookbook when cookbook.Id == Guid.Empty => _navigator.NavigateViewModelAsync<CreateCookbookModel>(this, qualifier: Qualifiers.Nested),
+            Cookbook cookbook => _navigator.NavigateViewModelAsync<CookbookDetailModel>(this, data: cookbook, qualifier: Qualifiers.Nested),
+            object obj when obj is not null && obj.GetType() != typeof(object) => _navigator.NavigateDataAsync(this, obj, qualifier: Qualifiers.Nested),
+            _ => Task.CompletedTask,
+        });
+    }
 
     public IFeed<User> UserProfile => _userService.UserFeed;
 }

--- a/src/Chefs/Presentation/ProfileModel.cs
+++ b/src/Chefs/Presentation/ProfileModel.cs
@@ -26,6 +26,8 @@ public partial class ProfileModel
         Profile = user != null ? State.Value(this, () => user) : userService.UserFeed;
     }
 
+    public Cookbook EmptyCookBook => new Cookbook();
+
     public IFeed<User> Profile { get; }
 
     public IFeed<int> RecipesCount => Profile.SelectAsync((user, ct) => _recipeService.GetCount(user.Id, ct));
@@ -42,11 +44,9 @@ public partial class ProfileModel
 
     public async ValueTask GoBack(CancellationToken ct) => await _navigator.NavigateBackAsync(this, cancellation: ct);
     
-    public async ValueTask TabletSettingsNavigation(CancellationToken ct)
+    public async ValueTask UpdateCookBookNavigation(Cookbook cookbook, CancellationToken ct)
     {
-        await _navigator.NavigateBackAsync(this, cancellation: ct);
+		await _navigator.NavigateBackWithResultAsync(this, data : cookbook.UpdateCookBook(), cancellation: ct);
 
-        //await _sourceNavigator.NavigateViewModelAsync<SettingsModel>(this, data: await Profile, cancellation: ct);
-        await _sourceNavigator.NavigateRouteAsync(this, "./MainGrid/Settings", cancellation: ct);
-    }
+	}
 }

--- a/src/Chefs/Presentation/UpdateCookbookModel.cs
+++ b/src/Chefs/Presentation/UpdateCookbookModel.cs
@@ -5,12 +5,12 @@ using Uno.Extensions;
 
 namespace Chefs.Presentation;
 
-public partial class UpdateCookbookModel // DR_REV: Use Model suffix instead of ViewModel
+public partial class UpdateCookbookModel
 {
     private readonly INavigator _navigator;
     private readonly IRecipeService _recipeService;
     private readonly ICookbookService _cookbookService;
-    private Cookbook _cookbook;
+    private readonly Cookbook _cookbook;
 
     public UpdateCookbookModel(
 		INavigator navigator,

--- a/src/Extensions.props
+++ b/src/Extensions.props
@@ -1,24 +1,22 @@
 <Project ToolsVersion="15.0">
   <ItemGroup>
-    <!--<PackageReference Include="Uno.Extensions.Authentication" Version="2.3.0-dev.712" />
-    <PackageReference Include="Uno.Extensions.Authentication.WinUI" Version="2.3.0-dev.712" />-->
-	<PackageReference Include="Uno.Extensions.Configuration" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Core" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Hosting" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Http" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Http.Refit" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Navigation" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Serialization" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Serialization.Http" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Reactive" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="2.3.0-dev.712" />
-	<PackageReference Include="Uno.Extensions.Reactive.Messaging" Version="2.3.0-dev.712" />
+	<PackageReference Include="Uno.Extensions.Configuration" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Core" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Hosting" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Hosting.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Http" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Http.Refit" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Localization.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Logging.Serilog" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Logging.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Navigation.Toolkit.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Navigation.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Navigation" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Serialization" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Serialization.Http" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Serialization.Refit" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Reactive" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Reactive.WinUI" Version="2.3.0-dev.823" />
+	<PackageReference Include="Uno.Extensions.Reactive.Messaging" Version="2.3.0-dev.823" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#519, closes unoplatform/uno.chefs-archived#493

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

- Fix navigation to the CreateCookBook from the ProfilePage

- Fix navigation to the UpdateCookBook from the ProfilePage 
(Related to this issue https://github.com/microsoft/microsoft-ui-xaml/issues/560, so using [utu:AncestorBinding](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/helpers/ancestor-itemscontrol-binding.md) instead)

- Fix navigation to the CookbookRecipeDetails from the ProfilePage

- Fix the SaveRecipe BindingExpression path error for the HomePage

- Fix the AuthOptions BindingExpression path error for the LoginPage

- Fix unoplatform/uno.chefs-archived#519 
(Related to this issue https://github.com/microsoft/microsoft-ui-xaml/issues/560, so using [utu:AncestorBinding](https://github.com/unoplatform/uno.toolkit.ui/blob/main/doc/helpers/ancestor-itemscontrol-binding.md) instead)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
