### PR TITLE
fix: Updating to latest Uno version to fix the [Android] Dinner, Lunch, Snack sections on HomePage don't show all the items

### DIFF
--- a/src/Chefs.Mobile/Chefs.Mobile.csproj
+++ b/src/Chefs.Mobile/Chefs.Mobile.csproj
@@ -29,8 +29,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI" Version="4.8.0-dev.630" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.630" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI" Version="4.8.0-dev.706" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.706" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">
@@ -80,7 +80,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
+++ b/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
@@ -20,8 +20,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.8.0-dev.630" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.630" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.8.0-dev.706" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.706" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -31,7 +31,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
+++ b/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
@@ -16,8 +16,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.8.0-dev.630" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.630" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.8.0-dev.706" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.706" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>
@@ -27,7 +27,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
+++ b/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.8.0-dev.630" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.630" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.8.0-dev.706" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.706" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -30,6 +30,6 @@
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
       <PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.3" />
 	  <PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 </Project>

--- a/src/Chefs.Tests/Chefs.Tests.csproj
+++ b/src/Chefs.Tests/Chefs.Tests.csproj
@@ -24,6 +24,6 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 </Project>

--- a/src/Chefs.UITests/Chefs.UITests.csproj
+++ b/src/Chefs.UITests/Chefs.UITests.csproj
@@ -40,7 +40,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 
 </Project>

--- a/src/Chefs.Wasm/Chefs.Wasm.csproj
+++ b/src/Chefs.Wasm/Chefs.Wasm.csproj
@@ -51,8 +51,8 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.8.0-dev.630" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.630" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.8.0-dev.706" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.0-dev.706" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.8" />
 	</ItemGroup>
@@ -62,7 +62,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" Condition="Exists('..\Chefs.UI\Chefs.UI.projitems')" />

--- a/src/Chefs.Windows/Chefs.Windows.csproj
+++ b/src/Chefs.Windows/Chefs.Windows.csproj
@@ -93,7 +93,7 @@
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.8.0-dev.630" />
+		<PackageReference Include="Uno.WinUI" Version="4.8.0-dev.706" />
 	</ItemGroup>
 
 	<!-- Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
@@ -122,7 +122,7 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 	<Import Project="..\Extensions.props" />
 	<Import Project="..\Chefs.UI\Chefs.UI.projitems" Label="Shared" />

--- a/src/Chefs/Chefs.csproj
+++ b/src/Chefs/Chefs.csproj
@@ -9,6 +9,6 @@
 	<ItemGroup>
 	  <PackageReference Update="Uno.Material.WinUI" Version="2.5.0-dev.14" />
 	  <PackageReference Update="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.35" />
-	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+	  <PackageReference Update="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.630" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.0-dev.706" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.5.0-dev.23" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#560

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Updating to the latest Uno dev version to fix the [Android] Dinner, Lunch, and Snack sections on HomePage don't show all the items


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
