### PR TITLE
fix: Remove workaround in place for Issue #246 as it is now fixed in Uno.Toolkit

### DIFF
--- a/src/Chefs.UI/Views/HomePage.xaml
+++ b/src/Chefs.UI/Views/HomePage.xaml
@@ -55,39 +55,36 @@
                                                    Stretch="UniformToFill"
                                                    Margin="0,-80,0,0" />
                                         </utu:AutoLayout>
-                                        <!-- Additional AutoLayout added here as a workaround for this issue: -->
-                                        <!-- https://github.com/unoplatform/uno.chefs/issues/246 -->
-                                        <utu:AutoLayout Padding="16">
-                                            <utu:AutoLayout Spacing="16"
-                                                            Orientation="Horizontal">
-                                                <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                                utu:AutoLayout.PrimaryAlignment="Stretch">
-                                                    <utu:AutoLayout PrimaryAxisAlignment="Center">
-                                                        <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-                                                                   TextWrapping="Wrap"
-                                                                   Text="{Binding Name}"
-                                                                   Style="{StaticResource TitleMedium}" />
-                                                        <TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-                                                                   TextWrapping="Wrap"
-                                                                   Text="{Binding TimeCal}" />
-                                                    </utu:AutoLayout>
+                                        <utu:AutoLayout Padding="16"
+                                                        Spacing="16"
+                                                        Orientation="Horizontal">
+                                            <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                            utu:AutoLayout.PrimaryAlignment="Stretch">
+                                                <utu:AutoLayout PrimaryAxisAlignment="Center">
+                                                    <TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+                                                               TextWrapping="Wrap"
+                                                               Text="{Binding Name}"
+                                                               Style="{StaticResource TitleMedium}" />
+                                                    <TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
+                                                               TextWrapping="Wrap"
+                                                               Text="{Binding TimeCal}" />
                                                 </utu:AutoLayout>
-                                                <ToggleButton utu:AutoLayout.CounterAlignment="Center"
-                                                              IsChecked="{Binding Save, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                              Command="{Binding SaveRecipe}"
-                                                              CommandParameter="{Binding}"
-                                                              Style="{StaticResource IconToggleButtonStyle}">
-                                                    <ToggleButton.Content>
-                                                        <PathIcon Data="{StaticResource Icon_Outline_Status_Bookmark}"
-                                                                  Foreground="{ThemeResource OnBackgroundBrush}" />
-                                                    </ToggleButton.Content>
-                                                    <um:ControlExtensions.AlternateContent>
-
-                                                        <PathIcon Data="{StaticResource Icon_Solid_Saved_ChefsApp}"
-                                                                  Foreground="{ThemeResource OnBackgroundBrush}" />
-                                                    </um:ControlExtensions.AlternateContent>
-                                                </ToggleButton>
                                             </utu:AutoLayout>
+                                            <ToggleButton utu:AutoLayout.CounterAlignment="Center"
+                                                          IsChecked="{Binding Save, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                          Command="{Binding SaveRecipe}"
+                                                          CommandParameter="{Binding}"
+                                                          Style="{StaticResource IconToggleButtonStyle}">
+                                                <ToggleButton.Content>
+                                                    <PathIcon Data="{StaticResource Icon_Outline_Status_Bookmark}"
+                                                              Foreground="{ThemeResource OnBackgroundBrush}" />
+                                                </ToggleButton.Content>
+                                                <um:ControlExtensions.AlternateContent>
+
+                                                    <PathIcon Data="{StaticResource Icon_Solid_Saved_ChefsApp}"
+                                                              Foreground="{ThemeResource OnBackgroundBrush}" />
+                                                </um:ControlExtensions.AlternateContent>
+                                            </ToggleButton>
                                         </utu:AutoLayout>
                                     </utu:AutoLayout>
                                 </DataTemplate>
@@ -159,13 +156,9 @@
         </VisualStateManager.VisualStateGroups>
         <utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
             <utu:AutoLayout x:Name="NavBarLayout"
-                            Padding="18,12">
-
-                <!-- Additional AutoLayout added here as a workaround for this issue: -->
-                <!-- https://github.com/unoplatform/uno.chefs/issues/246 -->
-                <utu:AutoLayout Orientation="Horizontal">
-
-                    <utu:AutoLayout x:Name="ProfileLayout"
+                            Padding="18,12"
+                            Orientation="Horizontal">
+                <utu:AutoLayout x:Name="ProfileLayout"
                                     Spacing="8"
                                     Orientation="Horizontal"
                                     utu:AutoLayout.PrimaryAlignment="Stretch">
@@ -196,25 +189,22 @@
                         </utu:AutoLayout>
                     </utu:AutoLayout>
 
-                    <utu:AutoLayout Spacing="8"
-                                    Orientation="Horizontal">
-                        <Button utu:AutoLayout.CounterAlignment="Center"
-                                Style="{StaticResource IconButtonStyle}"
-                                uen:Navigation.Request="Search">
-                            <PathIcon Data="{StaticResource Icon_Outline_Interface_Search}"
-                                      Foreground="{ThemeResource OnSurfaceBrush}" />
-                        </Button>
-                        <Button x:Name="NotificationButton"
-                                utu:AutoLayout.CounterAlignment="Center"
-                                Style="{StaticResource IconButtonStyle}"
-                                uen:Navigation.Request="!Notifications">
-                            <PathIcon Data="{StaticResource Icon_Outline_Alert_ChefsApp}"
-                                      Foreground="{ThemeResource OnSurfaceBrush}" />
-                        </Button>
-                    </utu:AutoLayout>
-
+                <utu:AutoLayout Spacing="8"
+                                Orientation="Horizontal">
+                    <Button utu:AutoLayout.CounterAlignment="Center"
+                            Style="{StaticResource IconButtonStyle}"
+                            uen:Navigation.Request="Search">
+                        <PathIcon Data="{StaticResource Icon_Outline_Interface_Search}"
+                                  Foreground="{ThemeResource OnSurfaceBrush}" />
+                    </Button>
+                    <Button x:Name="NotificationButton"
+                            utu:AutoLayout.CounterAlignment="Center"
+                            Style="{StaticResource IconButtonStyle}"
+                            uen:Navigation.Request="!Notifications">
+                        <PathIcon Data="{StaticResource Icon_Outline_Alert_ChefsApp}"
+                                  Foreground="{ThemeResource OnSurfaceBrush}" />
+                    </Button>
                 </utu:AutoLayout>
-
             </utu:AutoLayout>
 
             <ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"

--- a/src/Chefs.UI/Views/SettingsPage.xaml
+++ b/src/Chefs.UI/Views/SettingsPage.xaml
@@ -38,7 +38,7 @@
                                 Value="Horizontal" />
                         <Setter Target="ContentLayout.Spacing"
                                 Value="40" />
-                        <Setter Target="PaddingLayout.Padding"
+                        <Setter Target="ContentLayout.Padding"
                                 Value="40" />
                         <Setter Target="ProfileLayout.Background"
                                 Value="{ThemeResource BackgroundBrush}" />
@@ -99,12 +99,9 @@
                 <ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"
                               utu:AutoLayout.CounterAlignment="Stretch"
                               HorizontalScrollMode="Disabled">
-                    <!-- Additional AutoLayout added here as a workaround for this issue: -->
-                    <!-- https://github.com/unoplatform/uno.chefs/issues/246 -->
-                    <utu:AutoLayout x:Name="PaddingLayout"
-                                    Padding="18">
-                        <utu:AutoLayout x:Name="ContentLayout"
-                                        utu:AutoLayout.PrimaryAlignment="Stretch">
+                    <utu:AutoLayout x:Name="ContentLayout"
+                                    Padding="18"
+                                    utu:AutoLayout.PrimaryAlignment="Stretch">
                             <utu:AutoLayout x:Name="PersonalInfoLayout"
                                             Spacing="20"
                                             PrimaryAxisAlignment="Center"
@@ -352,7 +349,6 @@
                                 </utu:AutoLayout>
                             </utu:AutoLayout>
                         </utu:AutoLayout>
-                    </utu:AutoLayout>
                 </ScrollViewer>
             </utu:AutoLayout>
             <utu:AutoLayout x:Name="NarrowButtons"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#567

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Remove the workaround in place for Issue [[Bug] Horizontal AutoLayout right padding not working unoplatform/uno.chefs-archived#567](https://github.com/unoplatform/uno.chefs-archived/issues/567) as it is now fixed in Uno.Toolkit


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
