### PR TITLE
fix: Add WasmShellWebAppBasePath property for WASM as a workaround to fix the images' path (#404)

### DIFF
--- a/src/Chefs.Wasm/Chefs.Wasm.csproj
+++ b/src/Chefs.Wasm/Chefs.Wasm.csproj
@@ -5,6 +5,9 @@
 		<NoWarn>$(NoWarn);NU1504;NU1505;NU1701</NoWarn>
 		<DefineConstants>$(DefineConstants);WINUI</DefineConstants>
 		<ImplicitUsings>disable</ImplicitUsings>
+		<!-- Changing the root of the app to have the correct path for the images -->
+		<!-- Related details here : https://github.com/unoplatform/uno.chefs/issues/404 -->
+		<WasmShellWebAppBasePath>/</WasmShellWebAppBasePath>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(Configuration)'=='Debug'">
 		<MonoRuntimeDebuggerEnabled>true</MonoRuntimeDebuggerEnabled>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#486 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## Description

Add WasmShellWebAppBasePath property for WASM as a workaround to fix the images' path (#404)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
