### PR TITLE
fix: Keep Add icon centered in Cookbook template

### DIFF
--- a/src/Chefs.UI/Views/SavedRecipesPage.xaml
+++ b/src/Chefs.UI/Views/SavedRecipesPage.xaml
@@ -67,9 +67,9 @@
                                                             <AdaptiveTrigger MinWindowWidth="800" />
                                                         </VisualState.StateTriggers>
                                                         <VisualState.Setters>
-															<Setter Target="ImagesLayout.Height"
+                                                            <Setter Target="ImagesLayout.Height"
                                                                     Value="180" />
-														</VisualState.Setters>
+                                                        </VisualState.Setters>
                                                     </VisualState>
                                                 </VisualStateGroup>
                                             </VisualStateManager.VisualStateGroups>


### PR DESCRIPTION
relates to unoplatform/uno.chefs-archived#452 