### PR TITLE
fix(home): popular creators nav binding

### DIFF
--- a/src/Chefs.UI/Views/HomePage.xaml
+++ b/src/Chefs.UI/Views/HomePage.xaml
@@ -440,7 +440,7 @@
                                               HorizontalScrollBarVisibility="Hidden"
                                               VerticalScrollMode="Disabled">
                                     <muxc:ItemsRepeater ItemsSource="{Binding Data}"
-                                                        utu:CommandExtensions.Command="{Binding DataContext.ShowProfile, ElementName=PopularCreatorsFeedView}">
+                                                        utu:CommandExtensions.Command="{Binding Parent.ShowProfile}">
                                         <muxc:ItemsRepeater.Layout>
                                             <muxc:StackLayout Orientation="Horizontal"
                                                               Spacing="8" />


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#443

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Cant navigate by clicking on "Popular Creators".

## What is the new behavior?
^ should work now.

## PR Checklist

Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)