### PR TITLE
fix: Update Uno to latest to fix OpenPackageFileAsync/ReadPackageFile Async throwing an exception when trying to open/read multiple times the same file at the same time (#11620)

### DIFF
--- a/src/Chefs.Mobile/Chefs.Mobile.csproj
+++ b/src/Chefs.Mobile/Chefs.Mobile.csproj
@@ -29,8 +29,8 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.100" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.357" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.357" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'=='net6.0-android'">

--- a/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
+++ b/src/Chefs.Skia.Gtk/Chefs.Skia.Gtk.csproj
@@ -20,8 +20,8 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.100" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Gtk" Version="4.9.0-dev.357" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.357" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
+++ b/src/Chefs.Skia.Linux.FrameBuffer/Chefs.Skia.Linux.FrameBuffer.csproj
@@ -16,8 +16,8 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.100" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Linux.FrameBuffer" Version="4.9.0-dev.357" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.357" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="SkiaSharp.Views.Uno.WinUI" Version="2.88.1-preview.79" />
 		<PackageReference Include="SkiaSharp.Skottie" Version="2.88.3" />
 	</ItemGroup>

--- a/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
+++ b/src/Chefs.Skia.WPF/Chefs.Skia.WPF.csproj
@@ -11,8 +11,8 @@
 	<ItemGroup>
 		<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls" Version="7.1.100" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.Skia.Wpf" Version="4.9.0-dev.357" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.357" Condition="'$(Configuration)'=='Debug'" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Chefs.Wasm/Chefs.Wasm.csproj
+++ b/src/Chefs.Wasm/Chefs.Wasm.csproj
@@ -54,8 +54,8 @@
 		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
 		<PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.4.0" />
 		<PackageReference Include="Uno.UI.RuntimeTests.Engine" Version="0.14.0-dev.54" />
-		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.8.15" />
-		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.8.15" Condition="'$(Configuration)'=='Debug'" />
+		<PackageReference Include="Uno.WinUI.WebAssembly" Version="4.9.0-dev.357" />
+		<PackageReference Include="Uno.WinUI.RemoteControl" Version="4.9.0-dev.357" Condition="'$(Configuration)'=='Debug'" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="3.3.1" />
 		<PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.8" />
 	</ItemGroup>

--- a/src/Chefs.Windows/Chefs.Windows.csproj
+++ b/src/Chefs.Windows/Chefs.Windows.csproj
@@ -85,7 +85,7 @@
 		<Manifest Include="$(ApplicationManifest)" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.357" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="7.1.2" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />

--- a/src/Chefs/Chefs.csproj
+++ b/src/Chefs/Chefs.csproj
@@ -23,6 +23,6 @@
 		<UpToDateCheckInput Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Uno.WinUI" Version="4.8.15" />
+		<PackageReference Include="Uno.WinUI" Version="4.9.0-dev.357" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.8.15" />
+		<PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.0-dev.357" />
 		<PackageReference Include="Uno.Toolkit.WinUI.Material" Version="2.6.0-dev.13" />
 	</ItemGroup>
 


### PR DESCRIPTION
GitHub Issue (If applicable): fixes unoplatform/uno.chefs-archived#619 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

 Update Uno to the latest to fix OpenPackageFileAsync/ReadPackageFile Async throwing an exception when trying to open/read multiple times the same file at the same time (#11620)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

