### PR TITLE
fix(Filter): Databinding fix to avoid null data context (Workaround for https://github.com/unoplatform/uno/issues/11835)

### DIFF
--- a/src/Chefs.UI/Views/SearchPage.xaml
+++ b/src/Chefs.UI/Views/SearchPage.xaml
@@ -326,7 +326,11 @@
                                    Style="{StaticResource TitleLarge}" />
                     </utu:AutoLayout>
 
-                    <utu:AutoLayout PrimaryAxisAlignment="End"
+                    <!-- Workaround for https://github.com/unoplatform/uno/issues/11835 -->
+                    <!-- Databinding fix to avoid null data context -->
+                    <utu:AutoLayout x:Name="FilterButtonHost"
+                                    DataContext="{Binding Filter}"
+                                    PrimaryAxisAlignment="End"
                                     utu:AutoLayout.CounterAlignment="Start">
                         <Button Content="Filters"
                                 x:Name="FilterButton"
@@ -339,8 +343,8 @@
                                 Foreground="{Binding Filter.Value.HasFilter, 
                                                     Converter={StaticResource PrimarySurfaceColorConverter}}"
                                 Style="{StaticResource OutlinedButtonStyle}"
-                                uen:Navigation.Request="Filter"
-                                uen:Navigation.Data="{Binding Filter.Value, Mode=TwoWay }">
+                                uen:Navigation.Request="!Filter"
+                                uen:Navigation.Data="{Binding DataContext.Value, ElementName=FilterButtonHost, Mode=TwoWay}">
                             <um:ControlExtensions.Icon>
                                 <PathIcon Data="{StaticResource Icon_Outline_Filter_ChefsApp}" />
                             </um:ControlExtensions.Icon>


### PR DESCRIPTION
GitHub Issue (If applicable): fixes unoplatform/uno.chefs-archived#450 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## Description

Fix Filter : Databinding fix to avoid null data context (Workaround for https://github.com/unoplatform/uno/issues/11835)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
