### PR TITLE
fix(iOS): Add workaround to display properly DrawerFlyout content

### DIFF
--- a/src/Chefs.UI/Styles/Flyout.xaml
+++ b/src/Chefs.UI/Styles/Flyout.xaml
@@ -1,6 +1,7 @@
-﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <x:Double x:Key="DrawerFlyoutWidth">520</x:Double>
 
     <Style x:Key="CustomRightDrawerFlyoutPresenterStyle"
            TargetType="FlyoutPresenter"

--- a/src/Chefs.UI/Views/FilterContentPage.xaml
+++ b/src/Chefs.UI/Views/FilterContentPage.xaml
@@ -41,7 +41,7 @@
                         <Setter Target="MainLayout.CornerRadius"
                                 Value="40,0,0,40" />
                         <Setter Target="MainLayout.Width"
-                                Value="520" />
+                                Value="{StaticResource DrawerFlyoutWidth}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Chefs.UI/Views/FilterPage.xaml
+++ b/src/Chefs.UI/Views/FilterPage.xaml
@@ -16,7 +16,12 @@
     
     <!-- Workaround used here by separating the FilterPage / FilterContentPage into two files -->
     <!-- Details available here: https://github.com/unoplatform/uno.toolkit.ui/issues/482 -->
-    <Grid x:Name="MainLayout">
+
+    <!-- Specifying MinWidth and HorizontalAlignment as a workaround for iOS while using RightDrawerFlyout -->
+    <!-- https://github.com/unoplatform/uno.chefs/issues/423 -->
+    <Grid x:Name="MainLayout"
+          MinWidth="{StaticResource DrawerFlyoutWidth}"
+          HorizontalAlignment="Right">
         <Frame HorizontalAlignment="Stretch"
                VerticalAlignment="Stretch"
                HorizontalContentAlignment="Stretch"

--- a/src/Chefs.UI/Views/NotificationsContentPage.xaml
+++ b/src/Chefs.UI/Views/NotificationsContentPage.xaml
@@ -163,7 +163,7 @@
                         <Setter Target="MainLayout.CornerRadius"
                                 Value="0,40,40,0" />
                         <Setter Target="MainLayout.Width"
-                                Value="520" />
+                                Value="{StaticResource DrawerFlyoutWidth}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Chefs.UI/Views/NotificationsPage.xaml
+++ b/src/Chefs.UI/Views/NotificationsPage.xaml
@@ -16,7 +16,12 @@
     
     <!-- Workaround used here by separating the NotificationsPage / NotificationsContentPage into two files -->
     <!-- Details available here: https://github.com/unoplatform/uno.toolkit.ui/issues/482 -->
-    <Grid x:Name="MainLayout">
+
+    <!-- Specifying MinWidth and HorizontalAlignment as a workaround for iOS while using LeftDrawerFlyout -->
+    <!-- https://github.com/unoplatform/uno.chefs/issues/423 -->
+    <Grid x:Name="MainLayout"
+          MinWidth="{StaticResource DrawerFlyoutWidth}"
+          HorizontalAlignment="Left">
         <Frame HorizontalAlignment="Stretch"
                VerticalAlignment="Stretch"
                HorizontalContentAlignment="Stretch"

--- a/src/Chefs.UI/Views/ProfileDetailsPage.xaml
+++ b/src/Chefs.UI/Views/ProfileDetailsPage.xaml
@@ -139,7 +139,7 @@
 						<Setter Target="MainLayout.CornerRadius"
 								Value="0,40,40,0" />
 						<Setter Target="MainLayout.Width"
-								Value="632" />
+								Value="{StaticResource DrawerFlyoutWidth}" />
 						<Setter Target="TabletNavBar.Visibility"
 								Value="Visible" />
 						<Setter Target="PhoneNavBar.Visibility"

--- a/src/Chefs.UI/Views/ProfilePage.xaml
+++ b/src/Chefs.UI/Views/ProfilePage.xaml
@@ -13,11 +13,16 @@
                               mc:Ignorable="d"
                               x:Name="Root"
                               Placement="Full">
-    <Grid x:Name="MainLayout">
+
+    <!-- Specifying MinWidth as a workaround for iOS while using LeftDrawerFlyout -->
+    <!-- https://github.com/unoplatform/uno.chefs/issues/423 -->
+    <Grid x:Name="MainLayout"
+          MinWidth="{StaticResource DrawerFlyoutWidth}">
         <Frame uen:Region.Attached="true"
                HorizontalAlignment="Stretch"
                VerticalAlignment="Stretch"
                HorizontalContentAlignment="Stretch"
                VerticalContentAlignment="Stretch" />
     </Grid>
+    
 </local:ResponsiveDrawerFlyout>

--- a/src/Chefs.UI/Views/ReviewsContentPage.xaml
+++ b/src/Chefs.UI/Views/ReviewsContentPage.xaml
@@ -37,7 +37,7 @@
                         <Setter Target="MainLayout.CornerRadius"
                                 Value="40,0,0,40" />
                         <Setter Target="MainLayout.Width"
-                                Value="520" />
+                                Value="{StaticResource DrawerFlyoutWidth}" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Chefs.UI/Views/ReviewsPage.xaml
+++ b/src/Chefs.UI/Views/ReviewsPage.xaml
@@ -17,7 +17,10 @@
     <!-- Workaround used here by separating the ReviewsPage / ReviewsContentPage into two files -->
     <!-- Details available here: https://github.com/unoplatform/uno.toolkit.ui/issues/482 -->
 
-    <Grid x:Name="MainLayout">
+    <!-- Specifying MinWidth as a workaround for iOS while using RightDrawerFlyout -->
+    <!-- https://github.com/unoplatform/uno.chefs/issues/423 -->
+    <Grid x:Name="MainLayout"
+          MinWidth="{StaticResource DrawerFlyoutWidth}">
         <Frame HorizontalAlignment="Stretch"
                VerticalAlignment="Stretch"
                HorizontalContentAlignment="Stretch"


### PR DESCRIPTION
GitHub Issue (If applicable): fixes unoplatform/uno.chefs-archived#471

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

- Content of some LeftDrawerFlyout/RightDrawerFlyout is not visible on iOS
- Content of some LeftDrawerFlyout/RightDrawerFlyout is in the middle of the screen instead of on the right on iOS

## What is the new behavior?

Added workarounds so the DrawerFlyout content displays properly on the Left or Right side for iOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
