### PR TITLE
fix: dark/light theme on single switch

### DIFF
--- a/src/Chefs.UI/Views/SettingsPage.xaml
+++ b/src/Chefs.UI/Views/SettingsPage.xaml
@@ -9,11 +9,11 @@
       xmlns:uen="using:Uno.Extensions.Navigation.UI"
       xmlns:converters="using:Chefs.Converters"
       xmlns:um="using:Uno.Material"
-	  xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:not_mobile="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:toolkit="using:Uno.UI.Toolkit"
       mc:Ignorable="d">
-      
+
     <utu:AutoLayout>
         <utu:AutoLayout.Resources>
             <x:String x:Key="BitmapIcon_Close">F1 M 14 1.4099998474121094 L 12.59000015258789 0 L 7 5.590000152587891 L 1.4099998474121094 0 L 0 1.4099998474121094 L 5.590000152587891 7 L 0 12.59000015258789 L 1.4099998474121094 14 L 7 8.40999984741211 L 12.59000015258789 14 L 14 12.59000015258789 L 8.40999984741211 7 L 14 1.4099998474121094 Z</x:String>
@@ -105,231 +105,199 @@
                     <utu:AutoLayout x:Name="ContentLayout"
                                     Padding="18"
                                     utu:AutoLayout.PrimaryAlignment="Stretch">
-                            <utu:AutoLayout x:Name="PersonalInfoLayout"
-                                            Spacing="20"
-                                            PrimaryAxisAlignment="Center"
-                                            utu:AutoLayout.PrimaryAlignment="Stretch">
-                                <utu:AutoLayout x:Name="ProfileLayout"
-                                                CornerRadius="0,0,30,30"
-                                                Padding="0, 0, 0, 24">
-                                    <utu:AutoLayout Spacing="16"
-                                                    PrimaryAxisAlignment="Center">
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
-                                            <Border x:Name="ImageBorder"
-                                                    CornerRadius="30"
-                                                    utu:AutoLayout.CounterAlignment="Start"
-                                                    Height="100"
-                                                    Width="100">
-                                                <Image Source="{Binding Profile.UrlProfileImage}"
-                                                       Stretch="UniformToFill"
-                                                       VerticalAlignment="Center"
-                                                       HorizontalAlignment="Center" />
-                                            </Border>
-                                        </utu:AutoLayout>
-                                        <utu:AutoLayout Spacing="6"
-                                                        PrimaryAxisAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock x:Name="ProfileName"
-                                                       Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                       Text="{Binding Profile.FullName}"
-                                                       utu:AutoLayout.CounterAlignment="Center"
-                                                       Style="{StaticResource HeadlineMedium}" />
-                                            <TextBlock x:Name="ProfileDescription"
-                                                       Foreground="{ThemeResource OnSurfaceVariantBrush}"
-                                                       TextAlignment="Center"
-                                                       Text="{Binding Profile.Description}"
-                                                       utu:AutoLayout.CounterAlignment="Center"
-                                                       Style="{StaticResource TitleSmall}" />
-                                        </utu:AutoLayout>
+                        <utu:AutoLayout x:Name="PersonalInfoLayout"
+                                        Spacing="20"
+                                        PrimaryAxisAlignment="Center"
+                                        utu:AutoLayout.PrimaryAlignment="Stretch">
+                            <utu:AutoLayout x:Name="ProfileLayout"
+                                            CornerRadius="0,0,30,30"
+                                            Padding="0, 0, 0, 24">
+                                <utu:AutoLayout Spacing="16"
+                                                PrimaryAxisAlignment="Center">
+                                    <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
+                                        <Border x:Name="ImageBorder"
+                                                CornerRadius="30"
+                                                utu:AutoLayout.CounterAlignment="Start"
+                                                Height="100"
+                                                Width="100">
+                                            <Image Source="{Binding Profile.UrlProfileImage}"
+                                                   Stretch="UniformToFill"
+                                                   VerticalAlignment="Center"
+                                                   HorizontalAlignment="Center" />
+                                        </Border>
                                     </utu:AutoLayout>
-                                </utu:AutoLayout>
-
-                                <utu:AutoLayout Spacing="18"
-                                                utu:AutoLayout.PrimaryAlignment="Stretch">
-                                    <TextBlock x:Name="PersonalInformationTitle"
-                                               Foreground="{ThemeResource SurfaceInverseBrush}"
-                                               TextAlignment="Center"
-                                               Text="Personal information"
-                                               utu:AutoLayout.CounterAlignment="Start"
-                                               Style="{StaticResource BodyLarge}" />
-                                    <utu:AutoLayout x:Name="PersonalInformationInputs"
-                                                    Spacing="16"
-                                                    Padding="0"
-                                                    CornerRadius="16"
+                                    <utu:AutoLayout Spacing="6"
                                                     PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <TextBox x:Name="ProfileFullName"
-                                                 Text="{Binding Profile.FullName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 PlaceholderText="Full Name"
-                                                 Style="{StaticResource OutlinedTextBoxStyle}"
-                                                 Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                 PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
-                                                 BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
-                                                 Background="{ThemeResource SurfaceBrush}"
-                                                 CornerRadius="16"
-                                                 utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <um:ControlExtensions.Icon>
-                                                <ImageIcon Source="ms-appx:///Assets/Icons/leading_icon.png" />
-                                            </um:ControlExtensions.Icon>
-                                        </TextBox>
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="16"
-                                                    Padding="0"
-                                                    CornerRadius="16"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <TextBox x:Name="ProfileEmail"
-                                                 Text="{Binding Profile.Email, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 PlaceholderText="Email"
-                                                 Style="{StaticResource OutlinedTextBoxStyle}"
-                                                 Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                 PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
-                                                 BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
-                                                 Background="{ThemeResource SurfaceBrush}"
-                                                 CornerRadius="16"
-                                                 utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <um:ControlExtensions.Icon>
-                                                <ImageIcon Source="ms-appx:///Assets/Icons/email_icon.png" />
-                                            </um:ControlExtensions.Icon>
-                                        </TextBox>
-                                    </utu:AutoLayout>
-                                    <utu:AutoLayout Spacing="16"
-                                                    Padding="0"
-                                                    CornerRadius="16"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <TextBox x:Name="ProfilePhoneNumber"
-                                                 Text="{Binding Profile.PhoneNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                 PlaceholderText="Mobile Number"
-                                                 Style="{StaticResource OutlinedTextBoxStyle}"
-                                                 Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                 PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
-                                                 BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
-                                                 Background="{ThemeResource SurfaceBrush}"
-                                                 CornerRadius="16"
-                                                 utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <um:ControlExtensions.Icon>
-                                                <ImageIcon Source="ms-appx:///Assets/Icons/mobile_icon.png" />
-                                            </um:ControlExtensions.Icon>
-                                        </TextBox>
+                                                    utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <TextBlock x:Name="ProfileName"
+                                                   Foreground="{ThemeResource SurfaceInverseBrush}"
+                                                   Text="{Binding Profile.FullName}"
+                                                   utu:AutoLayout.CounterAlignment="Center"
+                                                   Style="{StaticResource HeadlineMedium}" />
+                                        <TextBlock x:Name="ProfileDescription"
+                                                   Foreground="{ThemeResource OnSurfaceVariantBrush}"
+                                                   TextAlignment="Center"
+                                                   Text="{Binding Profile.Description}"
+                                                   utu:AutoLayout.CounterAlignment="Center"
+                                                   Style="{StaticResource TitleSmall}" />
                                     </utu:AutoLayout>
                                 </utu:AutoLayout>
                             </utu:AutoLayout>
-                            <utu:AutoLayout x:Name="SettingsLayout"
-                                            utu:AutoLayout.PrimaryAlignment="Stretch"
-                                            utu:AutoLayout.CounterAlignment="Stretch">
-                                <utu:AutoLayout Spacing="18"
-                                                Padding="0,20">
-                                    <TextBlock x:Name="NotificationTitle"
-                                               Foreground="{ThemeResource SurfaceInverseBrush}"
-                                               TextAlignment="Center"
-                                               Text="Notification"
-                                               utu:AutoLayout.CounterAlignment="Start"
-                                               Style="{StaticResource BodyLarge}" />
-                                    <utu:AutoLayout x:Name="NotificationLayout"
-                                                    Background="{ThemeResource SurfaceBrush}"
-                                                    Spacing="16"
-                                                    Padding="16,0"
-                                                    CornerRadius="16"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout PrimaryAxisAlignment="Center"
-                                                        utu:AutoLayout.CounterAlignment="Center"
-                                                        Height="24"
-                                                        Width="60">
-                                            <Image Source="ms-appx:///Assets/Icons/bell_icon.png"
-                                                   Stretch="UniformToFill"
-                                                   utu:AutoLayout.CounterAlignment="Start"
-                                                   Height="24"
-                                                   Width="24" />
-                                        </utu:AutoLayout>
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                       TextWrapping="Wrap"
-                                                       Text="App notifications"
-                                                       Style="{StaticResource TitleMedium}" />
-                                        </utu:AutoLayout>
-                                        <ToggleSwitch IsOn="{Binding Settings.Notification, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                      Foreground="{ThemeResource PrimaryBrush}"
-                                                      utu:AutoLayout.CounterAlignment="Center"
-                                                      Height="70" />
-                                    </utu:AutoLayout>
+
+                            <utu:AutoLayout Spacing="18"
+                                            utu:AutoLayout.PrimaryAlignment="Stretch">
+                                <TextBlock x:Name="PersonalInformationTitle"
+                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                           TextAlignment="Center"
+                                           Text="Personal information"
+                                           utu:AutoLayout.CounterAlignment="Start"
+                                           Style="{StaticResource BodyLarge}" />
+                                <utu:AutoLayout x:Name="PersonalInformationInputs"
+                                                Spacing="16"
+                                                Padding="0"
+                                                CornerRadius="16"
+                                                PrimaryAxisAlignment="Center"
+                                                Orientation="Horizontal">
+                                    <TextBox x:Name="ProfileFullName"
+                                             Text="{Binding Profile.FullName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             PlaceholderText="Full Name"
+                                             Style="{StaticResource OutlinedTextBoxStyle}"
+                                             Foreground="{ThemeResource SurfaceInverseBrush}"
+                                             PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
+                                             BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
+                                             Background="{ThemeResource SurfaceBrush}"
+                                             CornerRadius="16"
+                                             utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <um:ControlExtensions.Icon>
+                                            <ImageIcon Source="ms-appx:///Assets/Icons/leading_icon.png" />
+                                        </um:ControlExtensions.Icon>
+                                    </TextBox>
                                 </utu:AutoLayout>
-                                <utu:AutoLayout Spacing="18"
-                                                Padding="0,20"
-                                                utu:AutoLayout.PrimaryAlignment="Stretch">
-                                    <TextBlock x:Name="ThemingTitle"
-                                               Foreground="{ThemeResource SurfaceInverseBrush}"
-                                               TextAlignment="Center"
-                                               Text="Theming"
+                                <utu:AutoLayout Spacing="16"
+                                                Padding="0"
+                                                CornerRadius="16"
+                                                PrimaryAxisAlignment="Center"
+                                                Orientation="Horizontal">
+                                    <TextBox x:Name="ProfileEmail"
+                                             Text="{Binding Profile.Email, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             PlaceholderText="Email"
+                                             Style="{StaticResource OutlinedTextBoxStyle}"
+                                             Foreground="{ThemeResource SurfaceInverseBrush}"
+                                             PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
+                                             BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
+                                             Background="{ThemeResource SurfaceBrush}"
+                                             CornerRadius="16"
+                                             utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <um:ControlExtensions.Icon>
+                                            <ImageIcon Source="ms-appx:///Assets/Icons/email_icon.png" />
+                                        </um:ControlExtensions.Icon>
+                                    </TextBox>
+                                </utu:AutoLayout>
+                                <utu:AutoLayout Spacing="16"
+                                                Padding="0"
+                                                CornerRadius="16"
+                                                PrimaryAxisAlignment="Center"
+                                                Orientation="Horizontal">
+                                    <TextBox x:Name="ProfilePhoneNumber"
+                                             Text="{Binding Profile.PhoneNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                             PlaceholderText="Mobile Number"
+                                             Style="{StaticResource OutlinedTextBoxStyle}"
+                                             Foreground="{ThemeResource SurfaceInverseBrush}"
+                                             PlaceholderForeground="{ThemeResource OnSurfaceVariantBrush}"
+                                             BorderBrush="{ThemeResource OnSurfaceVariantBrush}"
+                                             Background="{ThemeResource SurfaceBrush}"
+                                             CornerRadius="16"
+                                             utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <um:ControlExtensions.Icon>
+                                            <ImageIcon Source="ms-appx:///Assets/Icons/mobile_icon.png" />
+                                        </um:ControlExtensions.Icon>
+                                    </TextBox>
+                                </utu:AutoLayout>
+                            </utu:AutoLayout>
+                        </utu:AutoLayout>
+                        <utu:AutoLayout x:Name="SettingsLayout"
+                                        utu:AutoLayout.PrimaryAlignment="Stretch"
+                                        utu:AutoLayout.CounterAlignment="Stretch">
+                            <utu:AutoLayout Spacing="18"
+                                            Padding="0,20">
+                                <TextBlock x:Name="NotificationTitle"
+                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                           TextAlignment="Center"
+                                           Text="Notification"
+                                           utu:AutoLayout.CounterAlignment="Start"
+                                           Style="{StaticResource BodyLarge}" />
+                                <utu:AutoLayout x:Name="NotificationLayout"
+                                                Background="{ThemeResource SurfaceBrush}"
+                                                Spacing="16"
+                                                Padding="16,0"
+                                                CornerRadius="16"
+                                                PrimaryAxisAlignment="Center"
+                                                Orientation="Horizontal">
+                                    <utu:AutoLayout PrimaryAxisAlignment="Center"
+                                                    utu:AutoLayout.CounterAlignment="Center"
+                                                    Height="24"
+                                                    Width="60">
+                                        <Image Source="ms-appx:///Assets/Icons/bell_icon.png"
+                                               Stretch="UniformToFill"
                                                utu:AutoLayout.CounterAlignment="Start"
-                                               Style="{StaticResource BodyLarge}" />
-                                    <utu:AutoLayout x:Name="LightModeLayout"
-                                                    Background="{ThemeResource SurfaceBrush}"
-                                                    Spacing="16"
-                                                    Padding="16,0"
-                                                    CornerRadius="16"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout PrimaryAxisAlignment="Center"
-                                                        utu:AutoLayout.CounterAlignment="Center"
-                                                        Height="24"
-                                                        Width="60">
-                                            <Image Source="ms-appx:///Assets/Icons/sun_icon.png"
-                                                   Stretch="UniformToFill"
-                                                   utu:AutoLayout.CounterAlignment="Start"
-                                                   Height="24"
-                                                   Width="24" />
-                                        </utu:AutoLayout>
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                       TextWrapping="Wrap"
-                                                       Text="Light mode"
-                                                       Style="{StaticResource TitleMedium}" />
-                                        </utu:AutoLayout>
-                                        <ToggleSwitch IsOn="{Binding Settings.IsDark, 
-                                                         Mode=TwoWay, 
-                                                         UpdateSourceTrigger=PropertyChanged, 
-                                                         Converter={StaticResource InvertBool}}"
-                                                      Foreground="{ThemeResource PrimaryBrush}"
-                                                      utu:AutoLayout.CounterAlignment="Center"
-                                                      Height="70" />
+                                               Height="24"
+                                               Width="24" />
                                     </utu:AutoLayout>
-                                    <utu:AutoLayout x:Name="NightModeLayout"
-                                                    Background="{ThemeResource SurfaceBrush}"
-                                                    Spacing="16"
-                                                    Padding="16,0"
-                                                    CornerRadius="16"
-                                                    PrimaryAxisAlignment="Center"
-                                                    Orientation="Horizontal">
-                                        <utu:AutoLayout PrimaryAxisAlignment="Center"
-                                                        utu:AutoLayout.CounterAlignment="Center"
-                                                        Height="24"
-                                                        Width="60">
-                                            <Image Source="ms-appx:///Assets/Icons/moon_icon.png"
-                                                   Stretch="UniformToFill"
-                                                   utu:AutoLayout.CounterAlignment="Start"
-                                                   Height="24"
-                                                   Width="24" />
-                                        </utu:AutoLayout>
-                                        <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-                                                        utu:AutoLayout.PrimaryAlignment="Stretch">
-                                            <TextBlock Foreground="{ThemeResource SurfaceInverseBrush}"
-                                                       TextWrapping="Wrap"
-                                                       Text="Night mode"
-                                                       Style="{StaticResource TitleMedium}" />
-                                        </utu:AutoLayout>
-                                        <ToggleSwitch IsOn="{Binding Settings.IsDark, 
+                                    <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                    utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <TextBlock Foreground="{ThemeResource SurfaceInverseBrush}"
+                                                   TextWrapping="Wrap"
+                                                   Text="App notifications"
+                                                   Style="{StaticResource TitleMedium}" />
+                                    </utu:AutoLayout>
+                                    <ToggleSwitch IsOn="{Binding Settings.Notification, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                  Foreground="{ThemeResource PrimaryBrush}"
+                                                  utu:AutoLayout.CounterAlignment="Center"
+                                                  Height="70" />
+                                </utu:AutoLayout>
+                            </utu:AutoLayout>
+                            <utu:AutoLayout Spacing="18"
+                                            Padding="0,20"
+                                            utu:AutoLayout.PrimaryAlignment="Stretch">
+                                <TextBlock x:Name="ThemingTitle"
+                                           Foreground="{ThemeResource SurfaceInverseBrush}"
+                                           TextAlignment="Center"
+                                           Text="Theming"
+                                           utu:AutoLayout.CounterAlignment="Start"
+                                           Style="{StaticResource BodyLarge}" />
+                                <utu:AutoLayout x:Name="NightModeLayout"
+                                                Background="{ThemeResource SurfaceBrush}"
+                                                Spacing="16"
+                                                Padding="16,0"
+                                                CornerRadius="16"
+                                                PrimaryAxisAlignment="Center"
+                                                Orientation="Horizontal">
+                                    <utu:AutoLayout PrimaryAxisAlignment="Center"
+                                                    utu:AutoLayout.CounterAlignment="Center"
+                                                    Height="24"
+                                                    Width="60">
+                                        <Image Source="ms-appx:///Assets/Icons/moon_icon.png"
+                                               Stretch="UniformToFill"
+                                               utu:AutoLayout.CounterAlignment="Start"
+                                               Height="24"
+                                               Width="24" />
+                                    </utu:AutoLayout>
+                                    <utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+                                                    utu:AutoLayout.PrimaryAlignment="Stretch">
+                                        <TextBlock Foreground="{ThemeResource SurfaceInverseBrush}"
+                                                   TextWrapping="Wrap"
+                                                   Text="Night mode"
+                                                   Style="{StaticResource TitleMedium}" />
+                                    </utu:AutoLayout>
+                                    <ToggleSwitch IsOn="{Binding Settings.IsDark, 
                                                  Mode=TwoWay, 
                                                  UpdateSourceTrigger=PropertyChanged}"
-                                                      Foreground="{ThemeResource PrimaryBrush}"
-                                                      utu:AutoLayout.CounterAlignment="Center"
-                                                      Height="70" />
-                                    </utu:AutoLayout>
+                                                  Foreground="{ThemeResource PrimaryBrush}"
+                                                  utu:AutoLayout.CounterAlignment="Center"
+                                                  Height="70" />
+                                </utu:AutoLayout>
                                 <!--Commented accent color selection until https://github.com/unoplatform/uno.chefs/issues/78 implemented-->
-                                    <!--<utu:AutoLayout x:Name="AccentColorLayout"
+                                <!--<utu:AutoLayout x:Name="AccentColorLayout"
                                                     Spacing="18"
                                                     Padding="0,20">
                                         <TextBlock x:Name="AccentColorTitle"
@@ -355,9 +323,9 @@
                                                          utu:AutoLayout.PrimaryAlignment="Stretch" />
                                         </utu:AutoLayout>
                                     </utu:AutoLayout>-->
-                                </utu:AutoLayout>
                             </utu:AutoLayout>
                         </utu:AutoLayout>
+                    </utu:AutoLayout>
                 </ScrollViewer>
             </utu:AutoLayout>
             <utu:AutoLayout x:Name="NarrowButtons"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#433

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

Theres 2 switches to change app theme (dark, light)
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Single switch for changing themes
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
