### PR TITLE
refactor: Navigation method names

### DIFF
--- a/src/Chefs.UI/Views/ProfileDetailsPage.xaml
+++ b/src/Chefs.UI/Views/ProfileDetailsPage.xaml
@@ -173,7 +173,7 @@
 						</AppBarButton>
 					</utu:NavigationBar.MainCommand>
 					<utu:NavigationBar.PrimaryCommands>
-						<AppBarButton Command="{Binding SettingsNavigation}"
+                        <AppBarButton Command="{Binding NavigateToSettings}"
 									  Background="{ThemeResource BackgroundBrush}"
 									  Visibility="{Binding Profile.IsCurrent}">
 							<AppBarButton.Icon>
@@ -196,7 +196,7 @@
 						</AppBarButton>
 					</utu:NavigationBar.MainCommand>
 					<utu:NavigationBar.PrimaryCommands>
-						<AppBarButton Command="{Binding SettingsNavigation}"
+                        <AppBarButton Command="{Binding NavigateToSettings}"
 									  Visibility="{Binding Profile.IsCurrent}">
 							<AppBarButton.Icon>
 								<BitmapIcon UriSource="ms-appx:///Assets/Icons/settings.png" />
@@ -574,7 +574,7 @@
 																												   Visibility="{Binding CookbookImages.ThirdImage,
                                                                                                                                     Converter={StaticResource NullToCollapsed}}"/>
 
-																											<Button Command="{utu:AncestorBinding AncestorType=uer:FeedView, Path=DataContext.UpdateCookBookNavigation}"
+                                                                                                            <Button Command="{utu:AncestorBinding AncestorType=uer:FeedView, Path=DataContext.NavigateToUpdateCookBook}"
 																													CommandParameter="{Binding}"
 																													Background="{ThemeResource SurfaceVariantColor}"
 																													CornerRadius="12"
@@ -633,7 +633,7 @@
 											HorizontalAlignment="Right"
 											Margin="0,18">
 								<Button uen:Navigation.Request="-"
-										uen:Navigation.Data="{Binding EmptyCookBook}"
+										uen:Navigation.Data="{Binding EmptyCookbook}"
 										utu:AutoLayout.CounterAlignment="End"
 										CornerRadius="60"
 										Style="{StaticResource FabStyle}">

--- a/src/Chefs/Business/Models/Cookbook.cs
+++ b/src/Chefs/Business/Models/Cookbook.cs
@@ -49,5 +49,5 @@ public partial record Cookbook : IChefEntity
                 .ToList()
     };
 
-    internal UpdateCookbook UpdateCookBook() => new(this);
+    internal UpdateCookbook UpdateCookbook() => new(this);
 }

--- a/src/Chefs/Presentation/HomeModel.cs
+++ b/src/Chefs/Presentation/HomeModel.cs
@@ -71,15 +71,15 @@ public partial class HomeModel
 
     public async Task ShowProfile(User profile)
     {
-        await ProfileNavigation(profile);
+        await NavigateToProfile(profile);
     }
 
     public async Task ShowCurrentProfile()
     {
-        await ProfileNavigation();
+        await NavigateToProfile();
     }
 
-    private async Task ProfileNavigation(User? profile = null)
+    private async Task NavigateToProfile(User? profile = null)
     {
         var response = await _navigator.NavigateRouteForResultAsync<IChefEntity>(this, "Profile", data: profile);
         var result = await response!.Result;

--- a/src/Chefs/Presentation/ProfileModel.cs
+++ b/src/Chefs/Presentation/ProfileModel.cs
@@ -26,7 +26,7 @@ public partial class ProfileModel
         Profile = user != null ? State.Value(this, () => user) : userService.UserFeed;
     }
 
-    public Cookbook EmptyCookBook => new Cookbook();
+    public Cookbook EmptyCookbook => new Cookbook();
 
     public IFeed<User> Profile { get; }
 
@@ -37,16 +37,16 @@ public partial class ProfileModel
     public IListFeed<Recipe> Recipes => Profile.SelectAsync((user, ct) => _recipeService.GetByUser(user.Id, ct)).AsListFeed();
 
     //We kept this navigation as workaround for issue: https://github.com/unoplatform/uno.chefs/issues/103
-    public async ValueTask SettingsNavigation(CancellationToken ct)
+    public async ValueTask NavigateToSettings(CancellationToken ct)
     {
         await _navigator.NavigateViewModelAsync<SettingsModel>(this, data: await Profile, cancellation: ct);
     }
 
     public async ValueTask GoBack(CancellationToken ct) => await _navigator.NavigateBackAsync(this, cancellation: ct);
     
-    public async ValueTask UpdateCookBookNavigation(Cookbook cookbook, CancellationToken ct)
+    public async ValueTask NavigateToUpdateCookBook(Cookbook cookbook, CancellationToken ct)
     {
-		await _navigator.NavigateBackWithResultAsync(this, data : cookbook.UpdateCookBook(), cancellation: ct);
+		await _navigator.NavigateBackWithResultAsync(this, data : cookbook.UpdateCookbook(), cancellation: ct);
 
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#429 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?


- Bugfix


## What is the current behavior?

The method name for Navigation are in XXNavigatin()


## What is the new behavior?

The new format is NavigateToXXX()

## PR Checklist

Please check if your PR fulfills the following requirements:

-  Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
-  Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
-  Associated with an issue (GitHub or internal)




## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
