### PR TITLE
feat: New WelcomeModel logic

### DIFF
--- a/src/Chefs/Presentation/WelcomeModel.cs
+++ b/src/Chefs/Presentation/WelcomeModel.cs
@@ -4,12 +4,16 @@ public partial class WelcomeModel
 {
 	private readonly INavigator _navigator;
 
+	private const int PageCount = 3;
+
 	public WelcomeModel(INavigator navigator)
 	{
 		_navigator = navigator;
 	}
 
 	public IState<int> NextPage => State.Value(this, () => 0);
+
+	public IFeed<bool> HasNext => NextPage.Select(x => x < PageCount - 1);
 
 	public async ValueTask Next(int nextPage, CancellationToken ct)
 	{

--- a/src/Chefs/Views/WelcomePage.xaml
+++ b/src/Chefs/Views/WelcomePage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="Chefs.Views.WelcomePage"
+﻿<Page x:Class="Chefs.Views.WelcomePage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -9,15 +9,15 @@
 	  xmlns:uer="using:Uno.Extensions.Reactive.UI"
 	  xmlns:um="using:Uno.Material"
 	  xmlns:utu="using:Uno.Toolkit.UI"
+	  utu:SafeArea.Insets="Bottom"
 	  utu:StatusBar.Background="{ThemeResource SurfaceBrush}"
 	  utu:StatusBar.Foreground="Auto"
 	  Background="{ThemeResource SurfaceBrush}"
-	  utu:SafeArea.Insets="Bottom"
 	  NavigationCacheMode="Required"
 	  mc:Ignorable="d">
 
-	<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-					utu:AutoLayout.PrimaryAlignment="Stretch"
+	<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch"
+					Background="{ThemeResource SurfaceBrush}"
 					Spacing="32">
 		<!-- Onboarding pages as flip views -->
 		<FlipView x:Name="flipView"
@@ -28,107 +28,123 @@
 			<FlipView.Items>
 				<!-- First onboarding page -->
 				<utu:AutoLayout>
-					<Image Source="ms-appx:///Chefs/Assets/Welcome/first_splash_screen.png"
-						   Stretch="UniformToFill"
-						   Height="270.5" />
-					<utu:AutoLayout Spacing="24"
-									Padding="32,0"
+					<Image Height="270.5"
+						   Source="ms-appx:///Chefs/Assets/Welcome/first_splash_screen.png"
+						   Stretch="UniformToFill" />
+					<utu:AutoLayout Padding="32,0"
+									utu:AutoLayout.PrimaryAlignment="Stretch"
 									PrimaryAxisAlignment="Center"
-									utu:AutoLayout.PrimaryAlignment="Stretch">
+									Spacing="24">
 						<Image Width="160"
 							   Height="90"
 							   utu:AutoLayout.CounterAlignment="Center"
 							   Source="{ThemeResource ChefsLogoWithIcon}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleLarge}"
 								   Text="Welcome to Your App!"
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleLarge}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleMedium}"
 								   Text="Embark on a delightful coding journey as you discover, create, and share awesome script tailored to your app and project preferences."
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleMedium}" />
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
 					</utu:AutoLayout>
 				</utu:AutoLayout>
 				<!-- Second onboarding page -->
 				<utu:AutoLayout>
-					<Image Source="ms-appx:///Chefs/Assets/Welcome/second_splash_screen.png"
-						   Stretch="UniformToFill"
-						   Height="270.5" />
-					<utu:AutoLayout Spacing="24"
-									Padding="32,0"
+					<Image Height="270.5"
+						   Source="ms-appx:///Chefs/Assets/Welcome/second_splash_screen.png"
+						   Stretch="UniformToFill" />
+					<utu:AutoLayout Padding="32,0"
+									utu:AutoLayout.PrimaryAlignment="Stretch"
 									PrimaryAxisAlignment="Center"
-									utu:AutoLayout.PrimaryAlignment="Stretch">
+									Spacing="24">
 						<Image Width="160"
 							   Height="90"
 							   utu:AutoLayout.CounterAlignment="Center"
 							   Source="{ThemeResource ChefsLogoWithIcon}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleLarge}"
 								   Text="Explore Thousands of Recipes"
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleLarge}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleMedium}"
 								   Text="Find your next culinary adventure or last minute lunch from our vast collection of diverse and mouth-watering recipes."
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleMedium}" />
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
 					</utu:AutoLayout>
 				</utu:AutoLayout>
 				<!-- Third onboarding page -->
 				<utu:AutoLayout>
-					<Image Source="ms-appx:///Chefs/Assets/Welcome/third_splash_screen.png"
-						   Stretch="UniformToFill"
-						   Height="270.5" />
-					<utu:AutoLayout Spacing="24"
-									Padding="32,0"
+					<Image Height="270.5"
+						   Source="ms-appx:///Chefs/Assets/Welcome/third_splash_screen.png"
+						   Stretch="UniformToFill" />
+					<utu:AutoLayout Padding="32,0"
+									utu:AutoLayout.PrimaryAlignment="Stretch"
 									PrimaryAxisAlignment="Center"
-									utu:AutoLayout.PrimaryAlignment="Stretch">
+									Spacing="24">
 						<Image Width="160"
 							   Height="90"
 							   utu:AutoLayout.CounterAlignment="Center"
 							   Source="{ThemeResource ChefsLogoWithIcon}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleLarge}"
 								   Text="Personalize Your Recipe Journey"
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleLarge}" />
-						<TextBlock TextAlignment="Center"
-								   TextWrapping="Wrap"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleMedium}"
 								   Text="Create your own recipe collections, cookbooks, follow other foodies, and share your creations with the Chefs community."
-								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   Style="{StaticResource TitleMedium}" />
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
 					</utu:AutoLayout>
 				</utu:AutoLayout>
 			</FlipView.Items>
 		</FlipView>
 		<!-- Pips -->
 		<muxc:PipsPager x:Name="pipsPager"
+						utu:AutoLayout.CounterAlignment="Center"
 						MaxVisiblePips="3"
 						Orientation="Horizontal"
-						utu:AutoLayout.CounterAlignment="Center"
 						Style="{StaticResource PipsPagerStyle}" />
 		<!-- Buttons -->
-		<utu:AutoLayout Spacing="16"
-						Padding="32,0"
-						PrimaryAxisAlignment="Center">
-			<Button HorizontalContentAlignment="Center"
+		<utu:AutoLayout Padding="32,0"
+						PrimaryAxisAlignment="Center"
+						Spacing="16">
+
+			<!-- Next button always visible but not on the last slide -->
+			<Button Height="61"
+					HorizontalContentAlignment="Center"
 					VerticalContentAlignment="Center"
-					Content="Next"
-					Height="61"
-					Foreground="{ThemeResource OnPrimaryBrush}"
-					CornerRadius="4"
 					utu:FlipViewExtensions.Next="{Binding ElementName=flipView}"
-					Command="{Binding Next}" />
-			<Button HorizontalContentAlignment="Center"
-					VerticalContentAlignment="Center"
-					Content="Skip"
-					Height="61"
-					Foreground="{ThemeResource PrimaryBrush}"
+					Command="{Binding Next}"
+					Content="Next"
 					CornerRadius="4"
+					Foreground="{ThemeResource OnPrimaryBrush}"
+					Visibility="{Binding HasNext, Converter={StaticResource TrueToVisible}}" />
+
+			<!-- Skip button always visible but not on the last slide -->
+			<Button Height="61"
+					HorizontalContentAlignment="Center"
+					VerticalContentAlignment="Center"
+					uen:Navigation.Request="-/Login"
+					Content="Skip"
+					CornerRadius="4"
+					Foreground="{ThemeResource PrimaryBrush}"
 					Style="{StaticResource TextButtonStyle}"
-					uen:Navigation.Request="-/Login" />
+					Visibility="{Binding HasNext, Converter={StaticResource TrueToVisible}}" />
+
+			<!-- Get Started button only visible on the last slide -->
+			<Button Height="61"
+					HorizontalContentAlignment="Center"
+					VerticalContentAlignment="Center"
+					uen:Navigation.Request="-/Login"
+					Content="Get Started"
+					CornerRadius="4"
+					Foreground="{ThemeResource OnPrimaryBrush}"
+					Visibility="{Binding HasNext, Converter={StaticResource TrueToCollapsed}}" />
 		</utu:AutoLayout>
 	</utu:AutoLayout>
 </Page>

--- a/src/xaml-styler.json
+++ b/src/xaml-styler.json
@@ -11,19 +11,6 @@
 	"RemoveDesignTimeReferences":  false,
 	"IgnoreDesignTimeReferencePrefix": false,
 	"EnableAttributeReordering": false,
-	"AttributeOrderingRuleGroups": [
-		"x:Class",
-		"xmlns, xmlns:x",
-		"xmlns:*",
-		"x:Key, Key, x:Name, Name, x:Uid, Uid, Title",
-		"Grid.Row, Grid.RowSpan, Grid.Column, Grid.ColumnSpan, Canvas.Left, Canvas.Top, Canvas.Right, Canvas.Bottom",
-		"Width, Height, MinWidth, MinHeight, MaxWidth, MaxHeight",
-		"Margin, Padding, HorizontalAlignment, VerticalAlignment, HorizontalContentAlignment, VerticalContentAlignment, Panel.ZIndex",
-		"*:*, *",
-		"PageSource, PageIndex, Offset, Color, TargetName, Property, Value, StartPoint, EndPoint",
-		"mc:Ignorable, d:IsDataSource, d:LayoutOverrides, d:IsStaticText",
-		"Storyboard.*, From, To, Duration"
-	],
 	"FirstLineAttributes": "",
 	"OrderAttributesByName": false,
 	"PutEndingBracketOnNewLine": false,
@@ -39,5 +26,5 @@
 	"ThicknessSeparator": 2,
 	"ThicknessAttributes": "Margin, Padding, BorderThickness, ThumbnailClipMargin",
 	"FormatOnSave": false,
-	"CommentPadding": 1,
+	"CommentPadding": 1
 }


### PR DESCRIPTION
closes unoplatform/uno.chefs-archived#389 

## PR Type

What kind of change does this PR introduce?

- Feature

## What is the current behavior?

Next & Skip Buttons are always visible


## What is the new behavior?

`Next` & `Skip` buttons are available on the first 2 slides
Last slide now has a `Get Started` button


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
