### PR TITLE
fix: food images no longer misaligned

### DIFF
--- a/src/Chefs/Views/HomePage.xaml
+++ b/src/Chefs/Views/HomePage.xaml
@@ -30,9 +30,12 @@
 								PrimaryAxisAlignment="Center"
 								HorizontalAlignment="Stretch">
 					<utu:AutoLayout CornerRadius="4">
-						<Image Source="{Binding ImageUrl}"
-							   Stretch="UniformToFill"
-							   Height="144" />
+						<Border Height="144">
+							<Image HorizontalAlignment="Center"
+								   VerticalAlignment="Center"
+								   Source="{Binding ImageUrl}"
+								   Stretch="UniformToFill" />
+						</Border>
 						<utu:AutoLayout Spacing="16"
 										Padding="16"
 										Orientation="Horizontal">

--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -114,10 +114,13 @@
 				<utu:AutoLayout Spacing="8" 
 								utu:AutoLayout.CounterAlignment="Stretch" 
 								Height="250">
-					<Image Source="{Binding Recipe.ImageUrl}" 
-						   Stretch="UniformToFill" 
-						   utu:AutoLayout.CounterAlignment="Start" 
-						   Height="195" />
+					<Border Height="195" 
+							utu:AutoLayout.CounterAlignment="Start">
+						<Image Source="{Binding Recipe.ImageUrl}" 
+							   HorizontalAlignment="Center"
+							   VerticalAlignment="Center"
+							   Stretch="UniformToFill"/>
+					</Border>
 					<utu:AutoLayout utu:AutoLayout.IsIndependentLayout="True"
 									Margin="16,159,16,0" 
 									VerticalAlignment="Top" 

--- a/src/Chefs/Views/SearchPage.xaml
+++ b/src/Chefs/Views/SearchPage.xaml
@@ -103,10 +103,12 @@
                                     CornerRadius="4"
                                     PrimaryAxisAlignment="Center">
                                     <utu:AutoLayout CornerRadius="4">
-                                        <Image
-                                            Height="144"
-                                            Source="{x:Bind ImageUrl}"
-                                            Stretch="UniformToFill" />
+                                        <Border Height="144">
+                                            <Image HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   Source="{x:Bind ImageUrl}"
+                                                   Stretch="UniformToFill" />
+                                        </Border>
                                         <utu:AutoLayout
                                             Padding="16"
                                             PrimaryAxisAlignment="Center"


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#364 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/e03a62f7-1355-4a3e-890d-5362f5fe0b6a)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/271488f4-4866-45d9-bbd1-5e6541cf7dca)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/d84f9e0f-c179-4bb1-b583-7275e21a2346)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/59a25123-6d40-410a-b1c5-e9fc62ee6df8)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/0508d7dc-40da-43dc-a00c-bdb52432ced8)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/63949634-386d-44a5-97ef-7820acc78085)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/20e581bc-d693-42ae-9c36-cf0f0ac7e29e)
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/641aa2cd-44be-453e-908e-81af86c06958)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
For the workaround, I followed the example of the Favorites page where the alignment was ok - basically wrapping the image in a border that takes the image height; I'll have to check in a sample app if it's a Toolkit bug the fact that UniformToFill doesn't align the image properly.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
