### PR TITLE
fix: login button spacing

### DIFF
--- a/src/Chefs/Views/LoginPage.xaml
+++ b/src/Chefs/Views/LoginPage.xaml
@@ -127,7 +127,8 @@
 						</Button>
 					</utu:AutoLayout>
 					<utu:AutoLayout PrimaryAxisAlignment="Center"
-									Orientation="Horizontal">
+									Orientation="Horizontal"
+									Spacing="4">
 						<TextBlock Text="Not a member?"
 								   utu:AutoLayout.CounterAlignment="Center"
 								   Foreground="{ThemeResource OnSurfaceBrush}"
@@ -210,7 +211,8 @@
 								Command="{Binding Login}" />
 					</utu:AutoLayout>
 					<utu:AutoLayout PrimaryAxisAlignment="Center"
-									Orientation="Horizontal">
+									Orientation="Horizontal"
+									Spacing="4">
 						<TextBlock Text="Already a member?"
 								   utu:AutoLayout.CounterAlignment="Center"
 								   Foreground="{ThemeResource OnSurfaceBrush}"


### PR DESCRIPTION
GitHub Issue (If applicable): #
unoplatform/uno.chefs-archived#365
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?
Lacks some space between register now button and text before it
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/90481654/d7e1b94f-79a4-418b-abf6-97a2023dc890)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
