### PR TITLE
fix: map layer no longer blank in release

### DIFF
--- a/src/Chefs.Wasm/LinkerConfig.xml
+++ b/src/Chefs.Wasm/LinkerConfig.xml
@@ -9,8 +9,4 @@
 		<!-- This is required by System.Text.Json to properly deserialize ImmutableList across the App -->
 		<type fullname="System.Collections.Immutable.ImmutableList*" />
 	</assembly>
-	<assembly fullname="Mapsui">
-		<!-- This is required by Mapsui to display map tiles on WASM -->
-		<type fullname="Mapsui.Tiling*" />
-	</assembly>
 </linker>

--- a/src/Chefs/Views/MapPage.xaml.cs
+++ b/src/Chefs/Views/MapPage.xaml.cs
@@ -1,10 +1,11 @@
+using BruTile.Predefined;
 using Mapsui;
 using Mapsui.Extensions;
 using Mapsui.Layers;
 using Mapsui.Projections;
 using Mapsui.Providers;
 using Mapsui.Styles;
-using Mapsui.Tiling;
+using Mapsui.Tiling.Layers;
 using Mapsui.Utilities;
 using Mapsui.Widgets.Zoom;
 
@@ -46,10 +47,7 @@ public sealed partial class MapPage : Page
 
 	private static void AddBaseLayer()
 	{
-		_map!.Layers.Add(OpenStreetMap.CreateTileLayer());
-		// Add "using Mapsui.Tiling.Layers;" and uncomment following line to use a different tile source
-		//_map!.Layers.Add(layers: new TileLayer(KnownTileSources.Create(KnownTileSource.BingAerial)));
-
+		_map!.Layers.Add(layers: new TileLayer(KnownTileSources.Create(KnownTileSource.BingRoads)));
 		_map!.Widgets.Add(new ZoomInOutWidget { MarginX = 36, MarginY = 36 });
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#360 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/6ce91d6a-36b8-4ce0-9a00-14448f0be3b9)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/b63699f7-89d1-4163-84e6-3e734e15884c)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
I also added a comment in the map page code-behind to include an alternative way to create the base map layer. It allows the choice of a different tile source other than OSM, which is not documented in the Mapsui docs. 

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
