### PR TITLE
fix(ui): fix home contributors item padding

### DIFF
--- a/src/Chefs/Views/HomePage.xaml
+++ b/src/Chefs/Views/HomePage.xaml
@@ -303,6 +303,7 @@
 																	PrimaryAxisAlignment="Center">
 														<utu:AutoLayout Spacing="8"
 																		CornerRadius="12"
+																		Padding="10,8"
 																		utu:AutoLayout.CounterAlignment="Center">
 															<Border utu:AutoLayout.CounterAlignment="Center"
 																	Width="96"


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/uno.chefs-archived/issues/353

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Contributors item without padding

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
Padding added on Contributors item

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

|Before|After|
|--|--|
|<img width="85" alt="item-no-padding" src="https://github.com/unoplatform/uno.chefs/assets/34275909/9829524e-3fb2-4833-ab67-7c90068b5816">|<img width="114" alt="item-padding" src="https://github.com/unoplatform/uno.chefs/assets/34275909/545692c2-0cee-48ce-abd8-68a89669a0c2">|




