### PR TITLE
fix: Scroll bar showing when not needed

### DIFF
--- a/src/Chefs/Views/LoginPage.xaml
+++ b/src/Chefs/Views/LoginPage.xaml
@@ -37,7 +37,8 @@
 	</Page.Resources>
 	<utu:AutoLayout Background="{ThemeResource SurfaceBrush}">
 		<ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"
-					  HorizontalAlignment="Center">
+					  HorizontalAlignment="Center"
+					  VerticalScrollBarVisibility="Auto">
 			<Grid>
 				<utu:AutoLayout x:Name="LoginLayout"
 								Spacing="32"


### PR DESCRIPTION
GitHub Issue (If applicable): [#709](https://github.com/unoplatform/uno.chefs-archived/issues/367)

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

After resizing the wasm application from needing a scroll bar to no longer needing one an empty scroll bar remains.


## What is the new behavior?

After resizing the wasm application from needing a scroll bar to no longer needing one there is no scroll bar.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

none
