### PR TITLE
fix: Chips are not selected when you navigate to the filters page on …

### DIFF
--- a/src/Chefs/Views/FilterContentPage.xaml
+++ b/src/Chefs/Views/FilterContentPage.xaml
@@ -47,6 +47,7 @@
 						<TextBlock Style="{StaticResource TitleSmall}"
 								   Text="Recipe Categories"
 								   TextWrapping="Wrap" />
+						<!-- It's important to put the ItemsSource bove the SelectedItems, because, it will otherwise fail on WASM, see this issue: https://github.com/unoplatform/uno.toolkit.ui/issues/918 -->
 						<muxc:ItemsRepeater ItemsSource="{Binding OrganizeCategories}"
 											utu:ItemsRepeaterExtensions.SelectedItem="{Binding Filter.OrganizeCategory, Mode=TwoWay}"
 											utu:ItemsRepeaterExtensions.SelectionMode="SingleOrNone"


### PR DESCRIPTION
…wasm

GitHub Issue (If applicable): unoplatform/uno.chefs-archived#402

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

- Bugfix

## What is the current behavior?
When the extension tried to select the item, the ItemsSource was null, because the ItemsSource was set after the selected item was set. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
With the ItemsSource being set before the selected item, the selected item is being selected correctly
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
The reason it worked on other platform, I assume, is because selectedItem was a state and other platform handle the async aspect of the state differently
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
