### PR TITLE
refactor: Add Resource converter workaround

### DIFF
--- a/src/Chefs/Converters/BoolToResourceConverter.cs
+++ b/src/Chefs/Converters/BoolToResourceConverter.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.UI.Xaml.Data;
+
+namespace Chefs.Converters
+{
+    class BoolToResourceConverter : IValueConverter
+    {
+        public string? TrueValue { get; set; } = null;
+        public string? FalseValue { get; set; } = null;
+        public string? NullValue { get; set; } = null;
+
+        public object? Convert(object value, Type targetType, object parameter, string language)
+        {
+            return value is bool dValue
+                ? dValue ? ResolveResource(TrueValue) : ResolveResource(FalseValue)
+                : ResolveResource(NullValue);
+        }
+
+        private object? ResolveResource(string? name)
+            => Application.Current.Resources.TryGetValue(name, out object? value) ? value : null;
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+            => throw new NotImplementedException("Only one-way conversion is supported.");
+    }
+}

--- a/src/Chefs/Converters/Converters.xaml
+++ b/src/Chefs/Converters/Converters.xaml
@@ -1,72 +1,73 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converters="using:Chefs.Converters"
-                    xmlns:um="using:Uno.Material">
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:converters="using:Chefs.Converters"
+					xmlns:um="using:Uno.Material">
 
-    <converters:StringFormatter x:Key="StringFormatter" />
-    <converters:StringSeparatorConverter x:Key="DotStringSeparator"
-                                         Separator=" ∙ " />
-    <converters:CookingTimeFormatter x:Key="CookingTimeFormatter" />
+	<converters:StringFormatter x:Key="StringFormatter" />
+	<converters:StringSeparatorConverter x:Key="DotStringSeparator"
+										 Separator=" ∙ " />
+	<converters:CookingTimeFormatter x:Key="CookingTimeFormatter" />
 
-    <converters:TimeSpanToStringConverter x:Key="TimeSpanToStringConverter" />
-    <converters:BoolInverter x:Key="InvertBool" />
+	<converters:TimeSpanToStringConverter x:Key="TimeSpanToStringConverter" />
+	<converters:BoolInverter x:Key="InvertBool" />
 
-    <converters:GreaterThanZeroToVisibleConverter x:Key="GreaterThanZeroToVisibleConverter" />
+	<converters:GreaterThanZeroToVisibleConverter x:Key="GreaterThanZeroToVisibleConverter" />
 
-    <converters:CertainNumberToVisible x:Key="CertainNumberToVisibleConverter"
-                                       Number="2" />
+	<converters:CertainNumberToVisible x:Key="CertainNumberToVisibleConverter"
+									   Number="2" />
 
-    <converters:FromNullToVisibilityConverter x:Key="NullToCollapsed" />
-    <converters:FromNullToVisibilityConverter x:Key="NullToVisible"
-                                              Invert="True" />
+	<converters:FromNullToVisibilityConverter x:Key="NullToCollapsed" />
+	<converters:FromNullToVisibilityConverter x:Key="NullToVisible"
+											  Invert="True" />
 
-    <converters:StringReplacerConverter x:Key="WhiteSpaceToLineBreakConverter"
-                                        NewValue="&#x0a;"
-                                        OldValue=" " />
+	<converters:StringReplacerConverter x:Key="WhiteSpaceToLineBreakConverter"
+										NewValue="&#x0a;"
+										OldValue=" " />
 
-    <um:FromBoolToValueConverter x:Key="TrueToVisible"
-                                 FalseValue="Collapsed"
-                                 NullValue="Collapsed"
-                                 TrueValue="Visible" />
+	<um:FromBoolToValueConverter x:Key="TrueToVisible"
+								 FalseValue="Collapsed"
+								 NullValue="Collapsed"
+								 TrueValue="Visible" />
 
-    <um:FromBoolToValueConverter x:Key="TrueToCollapsed"
-                                 FalseValue="Visible"
-                                 NullValue="Visible"
-                                 TrueValue="Collapsed" />
+	<um:FromBoolToValueConverter x:Key="TrueToCollapsed"
+								 FalseValue="Visible"
+								 NullValue="Visible"
+								 TrueValue="Collapsed" />
 
-    <um:FromBoolToValueConverter x:Key="UserLikeColorConverter"
-                                 FalseValue="{StaticResource PrimaryMediumBrush}"
-                                 NullValue="{StaticResource PrimaryMediumBrush}"
-                                 TrueValue="{StaticResource PrimaryBrush}" />
+	<converters:BoolToResourceConverter x:Key="UserLikeColorConverter"
+										FalseValue="PrimaryMediumBrush"
+										NullValue="PrimaryMediumBrush"
+										TrueValue="PrimaryBrush" />
 
-    <um:FromBoolToValueConverter x:Key="IsCreatingCookbookToColorConverter"
-                                 FalseValue="{StaticResource PrimaryBrush}"
-                                 TrueValue="{StaticResource OnSurfaceMediumBrush}"
-                                 NullValue="{StaticResource OnSurfaceMediumBrush}" />
+	<converters:BoolToResourceConverter x:Key="IsCreatingCookbookToColorConverter"
+										FalseValue="PrimaryBrush"
+										TrueValue="OnSurfaceMediumBrush"
+										NullValue="OnSurfaceMediumBrush" />
 
-    <um:FromBoolToValueConverter x:Key="UserDislikeColorConverter"
-                                 FalseValue="{StaticResource PrimaryBrush}"
-                                 NullValue="{StaticResource PrimaryMediumBrush}"
-                                 TrueValue="{StaticResource PrimaryMediumBrush}" />
+	<converters:BoolToResourceConverter x:Key="UserDislikeColorConverter"
+										FalseValue="PrimaryBrush"
+										NullValue="PrimaryMediumBrush"
+										TrueValue="PrimaryMediumBrush" />
 
-    <um:FromBoolToValueConverter x:Key="UserLikeCheckedConverter"
-                                 FalseValue="False"
-                                 TrueValue="True"
-                                 NullValue="False" />
+	<um:FromBoolToValueConverter x:Key="UserLikeCheckedConverter"
+								 FalseValue="False"
+								 TrueValue="True"
+								 NullValue="False" />
 
-    <um:FromBoolToValueConverter x:Key="UserDislikeCheckedConverter"
-                                 FalseValue="True"
-                                 TrueValue="False"
-                                 NullValue="False" />
+	<um:FromBoolToValueConverter x:Key="UserDislikeCheckedConverter"
+								 FalseValue="True"
+								 TrueValue="False"
+								 NullValue="False" />
 
-    <converters:BoolToObjectConverter x:Key="BoolToNotificationColor"
-                                      TrueValue="{StaticResource SurfaceBrush}"
-                                      FalseValue="{StaticResource SurfaceTintBrush}" />
+	<converters:BoolToResourceConverter x:Key="BoolToNotificationColor"
+										TrueValue="SurfaceBrush"
+										FalseValue="SurfaceTintBrush" />
 
-    <converters:BoolToObjectConverter x:Key="PrimarySurfaceColorConverter"
-                                      FalseValue="{StaticResource PrimaryBrush}"
-                                      TrueValue="{StaticResource SurfaceBrush}" />
-    <converters:BoolToObjectConverter x:Key="FilterButtonBackgroundColor"
-                                      FalseValue="{StaticResource SurfaceBrush}"
-                                      TrueValue="{StaticResource PrimaryBrush}" />
+	<converters:BoolToResourceConverter x:Key="PrimarySurfaceColorConverter"
+										FalseValue="PrimaryBrush"
+										TrueValue="SurfaceBrush" />
+
+	<converters:BoolToResourceConverter x:Key="FilterButtonBackgroundColor"
+										FalseValue="SurfaceBrush"
+										TrueValue="PrimaryBrush" />
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#334

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

ThemeResource is not working in a converter, using StaticResource

## What is the new behavior?

using string to resource instead

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
