### PR TITLE
fix: Adding missing routemap for tabs on favouriterecipes page

### DIFF
--- a/src/Chefs/App.cs
+++ b/src/Chefs/App.cs
@@ -123,7 +123,12 @@ public class App : Application
 								new RouteMap("FilterContent", View: views.FindByViewModel<FilterModel>(), IsDefault:true)
 							}),
 						}),
-						new RouteMap("FavoriteRecipes", View: views.FindByViewModel<FavoriteRecipesModel>()),
+						new RouteMap("FavoriteRecipes", View: views.FindByViewModel<FavoriteRecipesModel>(),
+						Nested: new[]
+						{
+							new RouteMap("MyRecipes"),
+							new RouteMap("Cookbooks")
+						}),
 						new RouteMap("CookbookDetails", View: views.FindByViewModel<CookbookDetailModel>(), DependsOn: "FavoriteRecipes"),
 						new RouteMap("CookbookRecipeDetails", View: views.FindByViewModel<RecipeDetailsModel>(), DependsOn: "CookbookDetails"),
 						new RouteMap("CreateUpdateCookbook", View: views.FindByViewModel<CreateUpdateCookbookModel>(), DependsOn: "CookbookDetails"),


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#320

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Missing route causes fallback to default route provider that uses reflection (expensive lookup for viewmodels)

This is the warning that's in log output that points to this issue
```
Uno.Extensions.Navigation.MappedRouteResolver: Information: InternalDefaultMapping - For better performance (avoid reflection), create mapping for for path 'Cookbooks', view '', view model ''
```

## What is the new behavior?

No reflection when navigating

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
