### PR TITLE
fix: Adding missing routemap for tabs

### DIFF
--- a/src/Chefs/App.cs
+++ b/src/Chefs/App.cs
@@ -111,9 +111,6 @@ public class App : Application
 					{
 						new RouteMap("Home", View: views.FindByViewModel<HomeModel>(), IsDefault: true, Nested: new RouteMap[]
 						{
-							new RouteMap("Home"),
-							new RouteMap("Search"),
-							new RouteMap("FavoriteRecipes"),
 							new RouteMap("Notifications", View: views.FindByView<NotificationsFlyout>(), Nested: new RouteMap[]
 							{
 								new RouteMap("NotificationsContent", View: views.FindByViewModel<NotificationsModel>(), IsDefault:true, Nested: new[]


### PR DESCRIPTION
related https://github.com/unoplatform/uno.chefs-archived/issues/320

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

Missing route causes fallback to default route provider that uses reflection (expensive lookup for viewmodels)

This is the warning that's in log output that points to this issue
```
Uno.Extensions.Navigation.MappedRouteResolver: Information: InternalDefaultMapping - For better performance (avoid reflection), create mapping for for path 'Cookbooks', view '', view model ''
```

## What is the new behavior?

No reflection when navigating
