### PR TITLE
fix: NarrowTemplate recipe details Reviews and Steps now top aligned

### DIFF
--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -240,7 +240,6 @@
 
 										<utu:AutoLayout Padding="16,24"
 														uen:Region.Name="StepsTab"
-														PrimaryAxisAlignment="Center"
 														Spacing="8"
 														Visibility="Collapsed">
 											<TextBlock Style="{StaticResource BodyLarge}"
@@ -281,7 +280,6 @@
 
 										<utu:AutoLayout Padding="16,24"
 														uen:Region.Name="ReviewsTab"
-														PrimaryAxisAlignment="Center"
 														Spacing="8"
 														Visibility="Collapsed">
 											<TextBlock Style="{StaticResource BodyLarge}"


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#313 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On the recipe details page, in the NarrowTemplate, the Reviews and Steps tabs contents were centered.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The two tabs are now top-aligned.

![image](https://github.com/unoplatform/uno.chefs/assets/10283398/e90a60ab-6cbb-49ea-842c-ae6dc985862a)

The consequence of this change is that the Empty template for the Reviews tab is also top-aligned, whereas in Figma it's centered. The WideTemplate has same behavior. There is a discussion on the [Teams collab Chefs channel](https://teams.microsoft.com/l/message/19:af13aaf0a6364e3ebbb2dcb7046c9387@thread.tacv2/1702582542491?tenantId=a297d6c0-b635-41a3-b1e3-558efe71e413&groupId=8dc60687-928d-4478-bc08-5f38c17ee9cb&parentMessageId=1702582542491&teamName=Internal%20Projects%20Collab&channelName=Chefs&createdTime=1702582542491)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
