### PR TITLE
fix: randomize hard-coded json values for credibility

### DIFF
--- a/src/Chefs/Data/AppData/Cookbooks.json
+++ b/src/Chefs/Data/AppData/Cookbooks.json
@@ -59,7 +59,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "350 kcal",
         "Reviews": [
           {
             "Id": "bd95eeef-643e-4eb0-bbd8-1456791040f8",
@@ -174,7 +174,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "200 kcal",
         "Reviews": [
           {
             "Id": "9702c946-c6f0-4f18-91f0-a959990bb306",
@@ -280,7 +280,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "350 kcal",
         "Reviews": [
           {
             "Id": "6a0fa592-1b1d-4855-ba83-7f6fd0120830",
@@ -381,7 +381,7 @@
             "Quantity": "1000 gr"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "550 kcal",
         "Reviews": [
           {
             "Id": "9de1691e-da43-4788-8a98-0e5b2f2a2a6c",
@@ -496,7 +496,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "700 kcal",
         "Reviews": [
           {
             "Id": "5dad6dce-339c-4af1-b99c-f530946a8a1e",
@@ -586,7 +586,7 @@
             "Quantity": "200 ml"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "400 kcal",
         "Reviews": [
           {
             "Id": "6b07573b-cf63-420a-937b-dd004682523b",
@@ -684,7 +684,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "350 kcal",
         "Reviews": [
           {
             "RecipeId": "0dc51562-67b7-4de8-91fa-a0a4a538d919",
@@ -793,7 +793,7 @@
             "Quantity": "400 gr"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "150 kcal",
         "Reviews": [
           {
             "Id": "b79797c0-5255-4937-ac02-4df5f231c8ce",
@@ -896,7 +896,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "350 kcal",
         "Reviews": [
           {
             "Id": "6a0fa592-1b1d-4855-ba83-7f6fd0120830",
@@ -1005,7 +1005,7 @@
             "Quantity": "1000 gr"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "550 kcal",
         "Reviews": [
           {
             "Id": "9de1691e-da43-4788-8a98-0e5b2f2a2a6c",
@@ -1120,7 +1120,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "700 kcal",
         "Reviews": [
           {
             "Id": "5dad6dce-339c-4af1-b99c-f530946a8a1e",
@@ -1210,7 +1210,7 @@
             "Quantity": "200 ml"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "400 kcal",
         "Reviews": [
           {
             "Id": "6b07573b-cf63-420a-937b-dd004682523b",
@@ -1310,7 +1310,7 @@
             "Quantity": "400 gr"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "150 kcal",
         "Reviews": [
           {
             "Id": "b79797c0-5255-4937-ac02-4df5f231c8ce",
@@ -1413,7 +1413,7 @@
             "Quantity": "30 gr"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "150 kcal",
         "Reviews": [
           {
             "Id": "92ebde78-0049-4e8c-af6f-4e7dc6d6c0b2",
@@ -1538,7 +1538,7 @@
             "Quantity": "10 gr"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "200 kcal",
         "Reviews": [
           {
             "Id": "0d191b8a-993c-47b0-908c-30c5bc57980e",
@@ -1950,7 +1950,7 @@
             "Quantity": "400 ml"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "425 kcal",
         "Reviews": [
           {
             "Id": "25370a3f-7bca-4475-9575-3a7b54752e76",
@@ -2044,7 +2044,7 @@
             "Quantity": "400 ml"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "375 kcal",
         "Reviews": [
           {
             "Id": "40c710b9-e8bb-40f6-9115-03382aa138fa",
@@ -2266,7 +2266,7 @@
             "Quantity": "64 gr"
           }
         ],
-        "Calories": "266 kcal",
+        "Calories": "265 kcal",
         "Reviews": [
           {
             "Id": "0b6004c6-ea94-4716-b9c9-889c3570ed84",
@@ -2393,7 +2393,7 @@
             "Quantity": "5.3 gr"
           }
         ],
-        "Calories": "386 kcal",
+        "Calories": "385 kcal",
         "Reviews": [
           {
             "Id": "f84b52c1-3536-41ca-a077-3d423de32ff8",
@@ -2503,7 +2503,7 @@
             "Quantity": "2.5 gr"
           }
         ],
-        "Calories": "139 kcal",
+        "Calories": "150 kcal",
         "Reviews": [
           {
             "Id": "52728a86-a404-42be-a664-4c2e02aa250b",
@@ -2630,7 +2630,7 @@
             "Quantity": "2"
           }
         ],
-        "Calories": "402 kcal",
+        "Calories": "425 kcal",
         "Reviews": [
           {
             "Id": "537802b0-aa01-4e1d-8dd6-c6c60c8614e6",
@@ -2740,7 +2740,7 @@
             "Quantity": "96 gr"
           }
         ],
-        "Calories": "170 kcal",
+        "Calories": "550 kcal",
         "Reviews": [
           {
             "Id": "5d5f45db-dd02-449c-acd9-10b3dc51e011",
@@ -2840,7 +2840,7 @@
             "Quantity": "15 gr"
           }
         ],
-        "Calories": "284 kcal",
+        "Calories": "525 kcal",
         "Reviews": [
           {
             "Id": "38bf80d7-c477-4d6b-ab38-cb172e98267b",
@@ -2943,7 +2943,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "350 kcal",
         "Reviews": [
           {
             "Id": "6a0fa592-1b1d-4855-ba83-7f6fd0120830",
@@ -3044,7 +3044,7 @@
             "Quantity": "1000 gr"
           }
         ],
-        "Calories": "267 kcal",
+        "Calories": "550 kcal",
         "Reviews": [
           {
             "Id": "9de1691e-da43-4788-8a98-0e5b2f2a2a6c",
@@ -3159,7 +3159,7 @@
             "Quantity": "50 g"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "700 kcal",
         "Reviews": [
           {
             "Id": "5dad6dce-339c-4af1-b99c-f530946a8a1e",
@@ -3249,7 +3249,7 @@
             "Quantity": "200 ml"
           }
         ],
-        "Calories": "268 kcal",
+        "Calories": "400 kcal",
         "Reviews": [
           {
             "Id": "6b07573b-cf63-420a-937b-dd004682523b",

--- a/src/Chefs/Data/AppData/Recipes.json
+++ b/src/Chefs/Data/AppData/Recipes.json
@@ -68,7 +68,7 @@
         "Quantity": "salt to taste"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "250 kcal",
 		"Reviews": [],
     "Details": "Details",
     "Creator": {
@@ -144,7 +144,7 @@
         "Quantity": "50 g"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "350 kcal",
     "Reviews": [
       {
         "Id": "bd95eeef-643e-4eb0-bbd8-1456791040f8",
@@ -259,7 +259,7 @@
         "Quantity": "50 g"
       }
     ],
-    "Calories": "267 kcal",
+    "Calories": "200 kcal",
     "Reviews": [
       {
         "Id": "9702c946-c6f0-4f18-91f0-a959990bb306",
@@ -365,7 +365,7 @@
         "Quantity": "50 g"
       }
     ],
-    "Calories": "267 kcal",
+    "Calories": "350 kcal",
     "Reviews": [
       {
         "Id": "6a0fa592-1b1d-4855-ba83-7f6fd0120830",
@@ -466,7 +466,7 @@
         "Quantity": "1000 gr"
       }
     ],
-    "Calories": "267 kcal",
+    "Calories": "550 kcal",
     "Reviews": [
       {
         "Id": "9de1691e-da43-4788-8a98-0e5b2f2a2a6c",
@@ -581,7 +581,7 @@
         "Quantity": "50 g"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "700 kcal",
     "Reviews": [
       {
         "Id": "5dad6dce-339c-4af1-b99c-f530946a8a1e",
@@ -671,7 +671,7 @@
         "Quantity": "200 ml"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "400 kcal",
     "Reviews": [
       {
         "Id": "6b07573b-cf63-420a-937b-dd004682523b",
@@ -771,7 +771,7 @@
         "Quantity": "400 gr"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "150 kcal",
     "Reviews": [
       {
         "Id": "b79797c0-5255-4937-ac02-4df5f231c8ce",
@@ -866,7 +866,7 @@
         "Quantity": "30 gr"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "150 kcal",
     "Reviews": [
       {
         "Id": "92ebde78-0049-4e8c-af6f-4e7dc6d6c0b2",
@@ -991,7 +991,7 @@
         "Quantity": "10 gr"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "200 kcal",
     "Reviews": [
       {
         "Id": "0d191b8a-993c-47b0-908c-30c5bc57980e",
@@ -1395,7 +1395,7 @@
         "Quantity": "400 ml"
       }
     ],
-    "Calories": "267 kcal",
+    "Calories": "425 kcal",
     "Reviews": [
       {
         "Id": "25370a3f-7bca-4475-9575-3a7b54752e76",
@@ -1489,7 +1489,7 @@
         "Quantity": "400 ml"
       }
     ],
-    "Calories": "268 kcal",
+    "Calories": "375 kcal",
     "Reviews": [
       {
         "Id": "40c710b9-e8bb-40f6-9115-03382aa138fa",
@@ -1965,7 +1965,7 @@
         "Quantity": "2"
       }
     ],
-    "Calories": "402 kcal",
+    "Calories": "425 kcal",
     "Reviews": [
       {
         "Id": "537802b0-aa01-4e1d-8dd6-c6c60c8614e6",
@@ -2075,7 +2075,7 @@
         "Quantity": "96 gr"
       }
     ],
-    "Calories": "170 kcal",
+    "Calories": "550 kcal",
     "Reviews": [
       {
         "Id": "5d5f45db-dd02-449c-acd9-10b3dc51e011",
@@ -2175,7 +2175,7 @@
         "Quantity": "15 gr"
       }
     ],
-    "Calories": "284 kcal",
+    "Calories": "525 kcal",
     "Reviews": [
       {
         "Id": "38bf80d7-c477-4d6b-ab38-cb172e98267b",
@@ -3188,7 +3188,7 @@
         "Quantity": "64 gr"
       }
     ],
-    "Calories": "266 kcal",
+    "Calories": "265 kcal",
     "Reviews": [
       {
         "Id": "0b6004c6-ea94-4716-b9c9-889c3570ed84",
@@ -3307,7 +3307,7 @@
         "Quantity": "5.3 gr"
       }
     ],
-    "Calories": "386 kcal",
+    "Calories": "385 kcal",
     "Reviews": [
       {
         "Id": "f84b52c1-3536-41ca-a077-3d423de32ff8",
@@ -3417,7 +3417,7 @@
         "Quantity": "2.5 gr"
       }
     ],
-    "Calories": "139 kcal",
+    "Calories": "150 kcal",
     "Reviews": [
       {
         "Id": "52728a86-a404-42be-a664-4c2e02aa250b",

--- a/src/Chefs/Data/AppData/Users.json
+++ b/src/Chefs/Data/AppData/Users.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "Id": "3c896419-e280-40e7-8552-240635566fed",
     "UrlProfileImage": "ms-appx:///Chefs/Assets/Profiles/james_bondi.png",
@@ -21,7 +21,7 @@
     "Password": "123",
     "Followers": 147,
     "Following": 259,
-    "Recipes": 45
+    "Recipes": 23
   },
 
   {
@@ -34,7 +34,7 @@
     "Password": "123",
     "Followers": 314,
     "Following": 734,
-    "Recipes": 45
+    "Recipes": 11
   },
 
   {
@@ -47,7 +47,7 @@
     "Password": "123",
     "Followers": 12,
     "Following": 34,
-    "Recipes": 45
+    "Recipes": 56
   },
   {
     "Id": "02cbd790-905f-4f07-bd67-bfe3a6a8c56c",
@@ -59,7 +59,7 @@
     "Password": "123",
     "Followers": 234,
     "Following": 983,
-    "Recipes": 45
+    "Recipes": 38
   },
   {
     "Id": "3f848dba-f972-493a-bf52-0cd93958f4b2",
@@ -71,7 +71,7 @@
     "Password": "123",
     "Followers": 201,
     "Following": 934,
-    "Recipes": 45
+    "Recipes": 25
   },
   {
     "Id": "7f7cddd2-2e1e-4a99-a6e3-88575d2f66f1",
@@ -83,7 +83,7 @@
     "Password": "123",
     "Followers": 234,
     "Following": 983,
-    "Recipes": 45
+    "Recipes": 47
   },
   {
     "Id": "cf12f68f-ccc4-4740-87b3-acc984ac6821",
@@ -95,7 +95,7 @@
     "Password": "123",
     "Followers": 234,
     "Following": 983,
-    "Recipes": 45
+    "Recipes": 15
   },
   {
     "Id": "ebf3be76-2ff2-4325-94ec-ab9356daa8d2",


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#289 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A lot of users have the same value for the number of recipes.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
I updated the json hard-coded values so they're less repetitive. I did the same for the recipe Calories values.
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/c167e106-4fbc-467e-8b85-2ae507f82f5f)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
