### PR TITLE
fix: category recipe count is now calculated on Home page

### DIFF
--- a/src/Chefs/Business/Models/CategoryWithCount.cs
+++ b/src/Chefs/Business/Models/CategoryWithCount.cs
@@ -1,0 +1,13 @@
+namespace Chefs.Business.Models;
+
+public record CategoryWithCount
+{
+	internal CategoryWithCount(int count, Category category)
+	{
+		Count = count;
+		Category = category;
+	}
+
+	public int Count { get; init; }
+	public Category Category { get; init; }
+}

--- a/src/Chefs/Views/HomePage.xaml
+++ b/src/Chefs/Views/HomePage.xaml
@@ -165,17 +165,17 @@
 																Padding="8,0,16,0"
 																Orientation="Horizontal"
 																utu:AutoLayout.CounterAlignment="Start">
-													<Image Source="{Binding UrlIcon}"
+													<Image Source="{Binding Category.UrlIcon}"
 														   utu:AutoLayout.CounterAlignment="Center"
 														   Width="60"
 														   Height="60" />
 													<utu:AutoLayout PrimaryAxisAlignment="Center"
 																	utu:AutoLayout.CounterAlignment="Center">
-														<TextBlock Text="{Binding Name}"
+														<TextBlock Text="{Binding Category.Name}"
 																   utu:AutoLayout.CounterAlignment="Start"
 																   Foreground="{ThemeResource OnSurfaceBrush}"
 																   Style="{StaticResource TitleMedium}" />
-														<TextBlock Text="164 recipes"
+														<TextBlock Text="{Binding Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} recipes', UpdateSourceTrigger=PropertyChanged}"
 																   utu:AutoLayout.CounterAlignment="Start"
 																   Foreground="{ThemeResource OnSurfaceMediumBrush}" />
 													</utu:AutoLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#286 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/57793506-ff02-42ff-9f86-67e8372391bf)
The value was hard-coded in xaml.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The recipe count is now bound to the actual value
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/b130b9ce-6bcc-4e36-837f-607e5e14e01e)

e.g. Navigating to the Breakfast category will show the same result value 7
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/63ab0988-3622-441d-9050-ddc673091da4)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
