### PR TITLE
fix: added missing TabBar margin on Recipe Details wide

### DIFF
--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -519,6 +519,7 @@
 										utu:AutoLayout.PrimaryAlignment="Stretch">
 							<utu:TabBar uen:Region.Attached="True"
 										utu:AutoLayout.CounterAlignment="Center"
+										Margin="40,0"
 										Background="{ThemeResource BackgroundBrush}"
 										Style="{StaticResource TopTabBarStyle}">
 								<utu:TabBarItem uen:Region.Name="IngredientsTabWide"


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#283 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/7ca05a3b-13ea-452f-b731-f8ca7c89442c)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/b99149d2-e288-424c-813c-dbfe44b78eee)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
