### PR TITLE
fix: live cooking ingredients now properly aligned

### DIFF
--- a/src/Chefs/Data/AppData/Cookbooks.json
+++ b/src/Chefs/Data/AppData/Cookbooks.json
@@ -24,7 +24,7 @@
             "CookTime": "00:06:00",
             "Cookware": [ "Jar", "Skillet", "Knife", "Cutting Boards" ],
             "Description": "Place the dressing ingredients in a jar and shake together until well combined.\n\nAdd the mix salad greens first, then strategically place the carrot, onion, red pepper and cucumber around the mixed greens.",
-            "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "\nRed Papper", "Cucumber" ],
+            "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "Red Pepper", "Cucumber" ],
             "Number": 2,
             "UrlVideo": ""
           },
@@ -542,7 +542,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl", "Spoon" ],
             "Description": "Measure flour into a large mixing bowl.\n\nSlowly whisk in milk.\n\nWhisk in eggs, sugar, vanilla extract, cinnamon, and salt until smooth.",
-            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "\nVanilla extract", "\nCinnamon", "Salt" ],
+            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "Vanilla extract", "Cinnamon", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -649,7 +649,7 @@
             "CookTime": "00:06:00",
             "Cookware": [ "Jar", "Skillet", "Knife", "Cutting Boards" ],
             "Description": "Place the dressing ingredients in a jar and shake together until well combined.\n\nAdd the mix salad greens first, then strategically place the carrot, onion, red pepper and cucumber around the mixed greens.",
-            "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "\nRed Papper", "Cucumber" ],
+            "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "Red Pepper", "Cucumber" ],
             "Number": 2,
             "UrlVideo": ""
           },
@@ -739,7 +739,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl" ],
             "Description": "Bring the milk and water to a boil in a bowl.\n\nCombine flours, oats, dried cranberries and apricots, baking powder, and salt in a large mixing bowl.",
-            "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "\nApricots", "Salt" ],
+            "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "Apricots", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -748,7 +748,7 @@
             "CookTime": "00:01:00",
             "Cookware": [ "Pot", "Spoon" ],
             "Description": "Mix in the oats, and reduce heat to medium.\n\nStir in blueberries, applesauce, wheat germ, cinnamon, and sugar.",
-            "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "\nCinnamon", "Sugar" ],
+            "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "Cinnamon", "Sugar" ],
             "Number": 2,
             "UrlVideo": ""
           },
@@ -1166,7 +1166,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl", "Spoon" ],
             "Description": "Measure flour into a large mixing bowl.\n\nSlowly whisk in milk.\n\nWhisk in eggs, sugar, vanilla extract, cinnamon, and salt until smooth.",
-            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "\nVanilla extract", "\nCinnamon", "Salt" ],
+            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "Vanilla extract", "Cinnamon", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -1256,7 +1256,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl" ],
             "Description": "Bring the milk and water to a boil in a bowl.\n\nCombine flours, oats, dried cranberries and apricots, baking powder, and salt in a large mixing bowl.",
-            "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "\nApricots", "Salt" ],
+            "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "Apricots", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -1265,7 +1265,7 @@
             "CookTime": "00:01:00",
             "Cookware": [ "Pot", "Spoon" ],
             "Description": "Mix in the oats, and reduce heat to medium.\n\nStir in blueberries, applesauce, wheat germ, cinnamon, and sugar.",
-            "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "\nCinnamon", "Sugar" ],
+            "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "Cinnamon", "Sugar" ],
             "Number": 2,
             "UrlVideo": ""
           },
@@ -1382,7 +1382,7 @@
             "CookTime": "00:20:00",
             "Cookware": [ "SaucePan", "Spoon", "Wire rack" ],
             "Description": "Meanwhile, in a saucepan, combine the sugar, cream, cinnamon and salt.\n\nBring to a boil over medium heat, stirring constantly.\n\nRemove from the heat; stir in walnuts.\n\nRemove foil from crust; pour filling into crust.\n\nBake until golden brown, 20-25 minutes.\n\nCool on a wire rack.\n\nStore in the refrigerator.",
-            "Ingredients": [ "Sugar", "Cream", "Cinnamon", "Salt", "\nPeanuts" ],
+            "Ingredients": [ "Sugar", "Cream", "Cinnamon", "Salt", "Peanuts" ],
             "Number": 3,
             "UrlVideo": ""
           }
@@ -1459,7 +1459,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Mixing bowl" ],
             "Description": "In a small mixing bowl whisk together lemon juice, red wine vinegar, extra virgin oil oil, honey, garlic.",
-            "Ingredients": [ "Lemon juic", "Red wine vinegar", "Extra virgin oil oil", "Honey", "\nGarlic" ],
+            "Ingredients": [ "Lemon juic", "Red wine vinegar", "Extra virgin oil oil", "Honey", "Garlic" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -1584,7 +1584,7 @@
             "CookTime": "00:20:00",
             "Cookware": [ "Bowl", "Mixer", "Dough hook" ],
             "Description": "Twenty-four hours before serving, start the détrempe: In the bowl of a stand mixer fitted with the dough hook, combine the flour, sugar, salt and yeast, and stir to combine.",
-            "Ingredients": [ "Flour", "Sugar", "Salt", "Honey", "\nGarlic", "Yeast" ],
+            "Ingredients": [ "Flour", "Sugar", "Salt", "Honey", "Garlic", "Yeast" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -1725,7 +1725,7 @@
             "CookTime": "00:25:00",
             "Cookware": [ "Medium saucepan", "Whisk" ],
             "Description": "In a medium saucepan, mix together 1 cup of heavy cream, 1/2 cup of granulated sugar, and 1 teaspoon of vanilla extract.\n\nHeat the mixture over medium heat, whisking constantly, until it comes to a simmer.\n\nIn a small bowl, mix together 2 tablespoons of cornstarch and 2 tablespoons of cold water to make a slurry.\n\nSlowly pour the slurry into the saucepan and continue to whisk until the mixture thickens.\n\nRemove from heat and stir in 2 cups of sliced strawberries.\n\nPour the filling into the cooled crust and refrigerate for at least 2 hours before serving.",
-            "Ingredients": [ "Cream", "Sugar", "Vanilla extract", "Cornstarch", "\nWater", "Strawberries" ],
+            "Ingredients": [ "Cream", "Sugar", "Vanilla extract", "Cornstarch", "Water", "Strawberries" ],
             "Number": 3,
             "UrlVideo": ""
           }
@@ -2329,7 +2329,7 @@
             "CookTime": "00:03:00",
             "Cookware": [ "Mortar", "Tablespoon", "Cup" ],
             "Description": "Place chopped garlic, large pinch kosher salt, oregano, and thyme in a mortar; pound and stir with a pestle a few seconds. Add 1 tablespoon fresh parsley.\n\nPound and stir mixture until it turns into a paste, 1 or 2 minutes. Add 1/3 cup olive oil; mix about 1 minute to infuse olive oil with herbs and garlic.",
-            "Ingredients": [ "Garlic", "Oregano", "Thyme", "\nParsley", "Olive oil" ],
+            "Ingredients": [ "Garlic", "Oregano", "Thyme", "Parsley", "Olive oil" ],
             "Number": 2,
             "UrlVideo": ""
           },
@@ -2338,7 +2338,7 @@
             "CookTime": "00:03:00",
             "Cookware": [ "Bowl", "Fork" ],
             "Description": "Place bread crumbs in a mixing bowl. Transfer herb-garlic mixture to breadcrumbs. Add a pinch of salt, black pepper, pinch cayenne, remaining chopped parsley, and grated cheese. Mix with a fork to distribute ingredients evenly. Pinch a bit of the mixture; if it feels a bit dry and doesn't stick to your finger, drizzle in a bit more olive oil. Stir until mixture reaches desired consistency. 2 to 3 minutes.",
-            "Ingredients": [ "Bread crumbs", "Garlic", "\nGrated cheese", "Parsley", "Cayenne" ],
+            "Ingredients": [ "Bread crumbs", "Garlic", "Grated cheese", "Parsley", "Cayenne" ],
             "Number": 3,
             "UrlVideo": ""
           },
@@ -2439,7 +2439,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl" ],
             "Description": "Add panko and flour to a bowl and mix.\nAdd bell peppers, canned salmon, garlic, salt, pepper, egg, mayonnaise, Worcestershire sauce and cilantro. Mix until incorporated.",
-            "Ingredients": [ "Panko", "Flour", "Pepper", "Canned salmon", "\nGarlic", "Salt" ],
+            "Ingredients": [ "Panko", "Flour", "Pepper", "Canned salmon", "Garlic", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },
@@ -2457,7 +2457,7 @@
             "CookTime": "00:03:00",
             "Cookware": [ "Skillet" ],
             "Description": "Add patties to the skillet and cook for 2-3 minutes on each side or until golden brown.",
-            "Ingredients": [ "Pepper", "Egg", "Mayonnaise", "Worcestershire sauce", "\nCilantro" ],
+            "Ingredients": [ "Pepper", "Egg", "Mayonnaise", "Worcestershire sauce", "Cilantro" ],
             "Number": 3,
             "UrlVideo": ""
           }
@@ -2694,7 +2694,7 @@
             "CookTime": "00:40:00",
             "Cookware": [ "Pot" ],
             "Description": "Add potatoes, sweet potatoes, carrots, and mushrooms.\n\nBring to a boil, reduce heat and simmer covered for 30 minutes or until vegetables are tender.\n\nRemove lid and stir in green beans.\n\nThicken if desired (below) and simmer an additional 10 minutes uncovered.",
-            "Ingredients": [ "Potato", "Carrot", "Mushroom", "\nGreen beans" ],
+            "Ingredients": [ "Potato", "Carrot", "Mushroom", "Green beans" ],
             "Number": 3,
             "UrlVideo": ""
           }
@@ -3205,7 +3205,7 @@
             "CookTime": "00:05:00",
             "Cookware": [ "Bowl", "Spoon" ],
             "Description": "Measure flour into a large mixing bowl.\n\nSlowly whisk in milk.\n\nWhisk in eggs, sugar, vanilla extract, cinnamon, and salt until smooth.",
-            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "\nVanilla extract", "\nCinnamon", "Salt" ],
+            "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "Vanilla extract", "Cinnamon", "Salt" ],
             "Number": 1,
             "UrlVideo": ""
           },

--- a/src/Chefs/Data/AppData/Recipes.json
+++ b/src/Chefs/Data/AppData/Recipes.json
@@ -109,7 +109,7 @@
         "CookTime": "00:06:00",
         "Cookware": [ "Jar", "Skillet", "Knife", "Cutting Boards" ],
         "Description": "Place the dressing ingredients in a jar and shake together until well combined.\n\nAdd the mix salad greens first, then strategically place the carrot, onion, red pepper and cucumber around the mixed greens.",
-        "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "\nRed Papper", "Cucumber" ],
+        "Ingredients": [ "Tamari Soy", "Carrot", "Onion", "Red Pepper", "Cucumber" ],
         "Number": 2,
         "UrlVideo": ""
       },
@@ -627,7 +627,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Bowl", "Spoon" ],
         "Description": "Measure flour into a large mixing bowl.\n\nSlowly whisk in milk.\n\nWhisk in eggs, sugar, vanilla extract, cinnamon, and salt until smooth.",
-        "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "\nVanilla extract", "\nCinnamon", "Salt" ],
+        "Ingredients": [ "Flour", "Milk", "Eggs", "Sugar", "Vanilla extract", "Cinnamon", "Salt" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -717,7 +717,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Bowl" ],
         "Description": "Bring the milk and water to a boil in a bowl.\n\nCombine flours, oats, dried cranberries and apricots, baking powder, and salt in a large mixing bowl.",
-        "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "\nApricots", "Salt" ],
+        "Ingredients": [ "Water", "Milk", "Oats", "Cranberries", "Apricots", "Salt" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -726,7 +726,7 @@
         "CookTime": "00:01:00",
         "Cookware": [ "Pot", "Spoon" ],
         "Description": "Mix in the oats, and reduce heat to medium.\n\nStir in blueberries, applesauce, wheat germ, cinnamon, and sugar.",
-        "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "\nCinnamon", "Sugar" ],
+        "Ingredients": [ "Oats", "Blueberries", "Applesauce", "Wheat germ", "Cinnamon", "Sugar" ],
         "Number": 2,
         "UrlVideo": ""
       },
@@ -835,7 +835,7 @@
         "CookTime": "00:20:00",
         "Cookware": [ "SaucePan", "Spoon", "Wire rack" ],
         "Description": "Meanwhile, in a saucepan, combine the sugar, cream, cinnamon and salt.\n\nBring to a boil over medium heat, stirring constantly.\n\nRemove from the heat; stir in walnuts.\n\nRemove foil from crust; pour filling into crust.\n\nBake until golden brown, 20-25 minutes.\n\nCool on a wire rack.\n\nStore in the refrigerator.",
-        "Ingredients": [ "Sugar", "Cream", "Cinnamon", "Salt", "\nPeanuts" ],
+        "Ingredients": [ "Sugar", "Cream", "Cinnamon", "Salt", "Peanuts" ],
         "Number": 3,
         "UrlVideo": ""
       }
@@ -912,7 +912,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Mixing bowl" ],
         "Description": "In a small mixing bowl whisk together lemon juice, red wine vinegar, extra virgin oil oil, honey, garlic.",
-        "Ingredients": [ "Lemon juic", "Red wine vinegar", "Extra virgin oil oil", "Honey", "\nGarlic" ],
+        "Ingredients": [ "Lemon juic", "Red wine vinegar", "Extra virgin oil oil", "Honey", "Garlic" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -1037,7 +1037,7 @@
         "CookTime": "00:20:00",
         "Cookware": [ "Bowl", "Mixer", "Dough hook" ],
         "Description": "Twenty-four hours before serving, start the détrempe: In the bowl of a stand mixer fitted with the dough hook, combine the flour, sugar, salt and yeast, and stir to combine.",
-        "Ingredients": [ "Flour", "Sugar", "Salt", "Honey", "\nGarlic", "Yeast" ],
+        "Ingredients": [ "Flour", "Sugar", "Salt", "Honey", "Garlic", "Yeast" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -1170,7 +1170,7 @@
         "CookTime": "00:25:00",
         "Cookware": [ "Medium saucepan", "Whisk" ],
         "Description": "In a medium saucepan, mix together 1 cup of heavy cream, 1/2 cup of granulated sugar, and 1 teaspoon of vanilla extract.\n\nHeat the mixture over medium heat, whisking constantly, until it comes to a simmer.\n\nIn a small bowl, mix together 2 tablespoons of cornstarch and 2 tablespoons of cold water to make a slurry.\n\nSlowly pour the slurry into the saucepan and continue to whisk until the mixture thickens.\n\nRemove from heat and stir in 2 cups of sliced strawberries.\n\nPour the filling into the cooled crust and refrigerate for at least 2 hours before serving.",
-        "Ingredients": [ "Cream", "Sugar", "Vanilla extract", "Cornstarch", "\nWater", "Strawberries" ],
+        "Ingredients": [ "Cream", "Sugar", "Vanilla extract", "Cornstarch", "Water", "Strawberries" ],
         "Number": 3,
         "UrlVideo": ""
       }
@@ -1644,7 +1644,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Broiler", "Tablespoon" ],
         "Description": "Preheat the broiler to low heat.\n\nWhisk together the chili garlic sauce, 2 tablespoons of soy sauce, 1 tablespoon of sesame oil, sugar and vinegar until combined.",
-        "Ingredients": [ "Chili", "Garlic", "Sauce", "Soy", "\nOil", "Sugar", "Vinegar" ],
+        "Ingredients": [ "Chili", "Garlic", "Sauce", "Soy", "Oil", "Sugar", "Vinegar" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -1768,7 +1768,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Broiler", "Tablespoon" ],
         "Description": "Preheat the broiler to low heat.\n\nWhisk together the chili garlic sauce, 2 tablespoons of soy sauce, 1 tablespoon of sesame oil, sugar and vinegar until combined.",
-        "Ingredients": [ "Chili", "Garlic", "Sauce", "Soy", "\nOil", "Sugar", "Vinegar" ],
+        "Ingredients": [ "Chili", "Garlic", "Sauce", "Soy", "Oil", "Sugar", "Vinegar" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -2029,7 +2029,7 @@
         "CookTime": "00:40:00",
         "Cookware": [ "Pot" ],
         "Description": "Add potatoes, sweet potatoes, carrots, and mushrooms.\n\nBring to a boil, reduce heat and simmer covered for 30 minutes or until vegetables are tender.\n\nRemove lid and stir in green beans.\n\nThicken if desired (below) and simmer an additional 10 minutes uncovered.",
-        "Ingredients": [ "Potato", "Carrot", "Mushroom", "\nGreen beans" ],
+        "Ingredients": [ "Potato", "Carrot", "Mushroom", "Green beans" ],
         "Number": 3,
         "UrlVideo": ""
       }
@@ -2239,7 +2239,7 @@
         "CookTime": "00:25:00",
         "Cookware": [ "Skillet" ],
         "Description": "Meanwhile, heat olive oil in a large skillet or pan, making sure there is enough to cover the bottom of the pan, and sauté garlic until opaque but not browned. Stir in tomato paste.\n\nImmediately stir in the tomatoes, salt, and pepper.\n\nReduce heat, and simmer until pasta is ready, adding basil at the end.",
-        "Ingredients": [ "Olive oil", "Garlic", "Tomato", "Salt", "\nPepper", "Basil" ],
+        "Ingredients": [ "Olive oil", "Garlic", "Tomato", "Salt", "Pepper", "Basil" ],
         "Number": 3,
         "UrlVideo": ""
       },
@@ -2335,7 +2335,7 @@
         "CookTime": "00:15:00",
         "Cookware": [ "Pan" ],
         "Description": "In a large saucepan over medium heat, heat the oil.\n\nAdd the scallions, garlic, carrot, mushrooms, and cabbage. Cook, stirring often, for 3 minutes, or until the vegetables soften.\n\nStir in the ginger and brown sugar (if using) and cook for 30 seconds.\n\nFinally add the chicken broth and bring to a simmer.\n\nSimmer for 10 minutes.",
-        "Ingredients": [ "Oil", "Mushrooms", "Scallion", "Garlic", "\nCarrot", "Cabbage", "Ginger", "Sugar", "\nChicken" ],
+        "Ingredients": [ "Oil", "Mushrooms", "Scallion", "Garlic", "Carrot", "Cabbage", "Ginger", "Sugar", "Chicken" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -2487,7 +2487,7 @@
         "CookTime": "00:13:00",
         "Cookware": [ "Bowl" ],
         "Description": "Whisk Italian dressing and salad spice mix together until smooth.\n\nCombine pasta, tomatoes, bell peppers, and olives in a salad bowl; pour dressing over salad and toss to coat.",
-        "Ingredients": [ "Italian dressing", "Pasta", "Tomato", "Pepper", "\nOlive" ],
+        "Ingredients": [ "Italian dressing", "Pasta", "Tomato", "Pepper", "Olive" ],
         "Number": 3,
         "UrlVideo": ""
       }
@@ -2683,7 +2683,7 @@
         "CookTime": "00:40:00",
         "Cookware": [ "Saucepan" ],
         "Description": "In a large saucepan over medium heat, saute onion and garlic in olive oil until onion is translucent. Stir in tomatoes, salt, sugar and bay leaf.",
-        "Ingredients": [ "Onion", "Garlic", "Olive oil", "Tomato", "\nSalt", "Sugar", "Bay leaf" ],
+        "Ingredients": [ "Onion", "Garlic", "Olive oil", "Tomato", "Salt", "Sugar", "Bay leaf" ],
         "Number": 2,
         "UrlVideo": ""
       },
@@ -2814,7 +2814,7 @@
         "CookTime": "00:43:00",
         "Cookware": [ "Bowl" ],
         "Description": "Prepare dipping sauce: Combine soy sauce, rice vinegar, chives, sesame seeds, and chile sauce in a small bowl. Set aside.\n\n Mix pork, garlic, egg, chives, soy sauce, sesame oil, and ginger in a large bowl until thoroughly combined.",
-        "Ingredients": [ "Sauce", "Soy sauce", "Rice vinegar", "Sesame seeds", "\nChile sauce", "Pork", "Garlic", "Egg", "\nChives", "Sesame oil", "Ginger" ],
+        "Ingredients": [ "Sauce", "Soy sauce", "Rice vinegar", "Sesame seeds", "Chile sauce", "Pork", "Garlic", "Egg", "Chives", "Sesame oil", "Ginger" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -3024,7 +3024,7 @@
         "CookTime": "00:15:00",
         "Cookware": [ "Tablespoon", "Bowl", "Electric hand beaters", "Jug" ],
         "Description": "Mix 200g self-raising flour, 1 1/2 tablespoon baking powder, 1 tablespoon golden caster sugar and a pinch of salt together in a large bowl./n/nCreate a well in the centre with the back of your spoon then add 3 large eggs, 25g melted butter and 200ml milk.\n\nWhisk together either with a balloon whisk or electric hand beaters until smooth then pour into a jug.",
-        "Ingredients": [ "Flour", "Baking powder", "Sugar", "Salt", "\nEgg", "Butter", "Milk" ],
+        "Ingredients": [ "Flour", "Baking powder", "Sugar", "Salt", "Egg", "Butter", "Milk" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -3243,7 +3243,7 @@
         "CookTime": "00:03:00",
         "Cookware": [ "Mortar", "Tablespoon", "Cup" ],
         "Description": "Place chopped garlic, large pinch kosher salt, oregano, and thyme in a mortar; pound and stir with a pestle a few seconds. Add 1 tablespoon fresh parsley.\n\nPound and stir mixture until it turns into a paste, 1 or 2 minutes. Add 1/3 cup olive oil; mix about 1 minute to infuse olive oil with herbs and garlic.",
-        "Ingredients": [ "Garlic", "Oregano", "Thyme", "\nParsley", "Olive oil" ],
+        "Ingredients": [ "Garlic", "Oregano", "Thyme", "Parsley", "Olive oil" ],
         "Number": 2,
         "UrlVideo": ""
       },
@@ -3252,7 +3252,7 @@
         "CookTime": "00:03:00",
         "Cookware": [ "Bowl", "Fork" ],
         "Description": "Place bread crumbs in a mixing bowl. Transfer herb-garlic mixture to breadcrumbs. Add a pinch of salt, black pepper, pinch cayenne, remaining chopped parsley, and grated cheese. Mix with a fork to distribute ingredients evenly. Pinch a bit of the mixture; if it feels a bit dry and doesn't stick to your finger, drizzle in a bit more olive oil. Stir until mixture reaches desired consistency. 2 to 3 minutes.",
-        "Ingredients": [ "Bread crumbs", "Garlic", "\nGrated cheese", "Parsley", "Cayenne" ],
+        "Ingredients": [ "Bread crumbs", "Garlic", "Grated cheese", "Parsley", "Cayenne" ],
         "Number": 3,
         "UrlVideo": ""
       },
@@ -3353,7 +3353,7 @@
         "CookTime": "00:05:00",
         "Cookware": [ "Bowl" ],
         "Description": "Add panko and flour to a bowl and mix.\nAdd bell peppers, canned salmon, garlic, salt, pepper, egg, mayonnaise, Worcestershire sauce and cilantro. Mix until incorporated.",
-        "Ingredients": [ "Panko", "Flour", "Pepper", "Canned salmon", "\nGarlic", "Salt" ],
+        "Ingredients": [ "Panko", "Flour", "Pepper", "Canned salmon", "Garlic", "Salt" ],
         "Number": 1,
         "UrlVideo": ""
       },
@@ -3371,7 +3371,7 @@
         "CookTime": "00:03:00",
         "Cookware": [ "Skillet" ],
         "Description": "Add patties to the skillet and cook for 2-3 minutes on each side or until golden brown.",
-        "Ingredients": [ "Pepper", "Egg", "Mayonnaise", "Worcestershire sauce", "\nCilantro" ],
+        "Ingredients": [ "Pepper", "Egg", "Mayonnaise", "Worcestershire sauce", "Cilantro" ],
         "Number": 3,
         "UrlVideo": ""
       }


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#275 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/72fd3cf4-f71c-4c59-956e-7c9e0df340db)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/ad26aede-f7d1-4021-8329-09b04bdf393e)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
