### PR TITLE
fix: search term no longer ignored when category filter is applied

### DIFF
--- a/src/Chefs/Presentation/SearchModel.cs
+++ b/src/Chefs/Presentation/SearchModel.cs
@@ -48,20 +48,24 @@ public partial class SearchModel
 
 	private IImmutableList<Recipe> ApplyFilter((IImmutableList<Recipe> recipes, SearchFilter filter) inputs)
 	{
+		IImmutableList<Recipe> recipesByTerm;
+		IImmutableList<Recipe> recipesByCategory;
+		recipesByCategory = recipesByTerm = inputs.recipes;
+
 		if (inputs.filter.OrganizeCategory is not null)
 		{
 			var selectedOrganizedCategory = inputs.filter.OrganizeCategory;
 
-			inputs.recipes = selectedOrganizedCategory switch
+			recipesByCategory = selectedOrganizedCategory switch
 			{
 				OrganizeCategory.Popular => _recipeService.GetPopular(CancellationToken.None).Result,
 				OrganizeCategory.Trending => _recipeService.GetTrending(CancellationToken.None).Result,
 				OrganizeCategory.Recent => _recipeService.GetRecent(CancellationToken.None).Result,
-				_ => inputs.recipes
+				_ => recipesByCategory
 			};
 		}
 
-		return inputs.recipes.Where(p => inputs.filter.Match(p)).ToImmutableList();
+		return recipesByCategory.Intersect(recipesByTerm).Where(p => inputs.filter.Match(p)).ToImmutableList();
 	}
 
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#273 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Whenever one of the Categories filter would be selected
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/77cc5efa-5b5b-4c5b-a840-adbd5e9effe1)
the search term would be ignored, because the list that was filtered by the search term would get overwritten by the list of recipes by category.
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/5b8356d8-6d48-40ff-8c15-74874978c948)


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The search term is no longer ignored, regardless of which filter is applied.
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/3e42b113-09fa-4861-bd65-e9f557e79cd0)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
