### PR TITLE
fix: Navigate to Favorite Recipe to LiveCooking and coming back.

### DIFF
--- a/src/Chefs/App.cs
+++ b/src/Chefs/App.cs
@@ -162,7 +162,6 @@ public class App : Application
 					{
 						new RouteMap("ReviewsContent", View: views.FindByViewModel<ReviewsModel>(), DependsOn: "RecipeDetails", IsDefault:true)
 					}),
-					new RouteMap("FavoriteRecipeDetails", View: views.FindByViewModel<RecipeDetailsModel>()),
 					new RouteMap("FavoriteCreateUpdateCookbook", View: views.FindByViewModel<CreateUpdateCookbookModel>()),
 					new RouteMap("Profile", View: views.FindByView<ProfileFlyout>(), Nested: new RouteMap[]
 					{

--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -1,4 +1,4 @@
-<Page x:Class="Chefs.Views.FavoriteRecipesPage"
+﻿<Page x:Class="Chefs.Views.FavoriteRecipesPage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -318,7 +318,8 @@
 									<utu:AutoLayout Padding="0,0,0,16"
 													HorizontalAlignment="Center"
 													Spacing="8">
-										<muxc:ItemsRepeater uen:Navigation.Request="!FavoriteRecipeDetails"
+										<muxc:ItemsRepeater uen:Navigation.Request="RecipeDetails"
+															uen:Navigation.Data="{Binding Data}"
 															ItemTemplate="{StaticResource RecipeTemplate}"
 															ItemsSource="{Binding Data}"
 															Layout="{utu:Responsive Narrow={StaticResource NarrowGridLayout},


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

Open a recipeDetails from favorite tab open a flyout. Open LiveCooking is add to the side of the current page. Going back from live cooking set a null recipe to the recipePage.


## What is the new behavior?
Open a RecipeDetails form favorite open a new page. Going to LiveCooking open a new page. Going back from liveCooking work properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
