### PR TITLE
fix: show Clear filters button when filters applied

### DIFF
--- a/src/Chefs/Presentation/SearchModel.cs
+++ b/src/Chefs/Presentation/SearchModel.cs
@@ -32,6 +32,8 @@ public partial class SearchModel
 
 	public IFeed<bool> Searched => Feed.Combine(Filter, Term).Select(GetSearched);
 
+	public IFeed<bool> HasFilter => Filter.Select(f => f.HasFilter);
+
 	public IListFeed<Recipe> Recommended => ListFeed.Async(_recipeService.GetRecommended);
 
 	public IListFeed<Recipe> FromChefs => ListFeed.Async(_recipeService.GetFromChefs);
@@ -88,4 +90,7 @@ public partial class SearchModel
 	{
 		await _navigator.NavigateToNotifications(this);
 	}
+
+	public async ValueTask ResetFilters(CancellationToken ct) =>
+		await Filter.Update(current => new SearchFilter(null, null, null, null, null), ct);
 }

--- a/src/Chefs/Views/SearchPage.xaml
+++ b/src/Chefs/Views/SearchPage.xaml
@@ -169,23 +169,39 @@
 					<TextBlock utu:AutoLayout.CounterAlignment="Center"
 							   Style="{StaticResource BodyLarge}"
 							   Text="{Binding Items.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} results', UpdateSourceTrigger=PropertyChanged}" />
-					<utu:AutoLayout x:Name="FilterButtonHost"
-									DataContext="{Binding Filter}">
-						<Button x:Name="FiltersButton"
-								HorizontalContentAlignment="Center"
-								VerticalContentAlignment="Center"
-								uen:Navigation.Data="{Binding DataContext.Value, ElementName=FilterButtonHost, Mode=TwoWay}"
-								uen:Navigation.Request="!Filter"
+					<utu:AutoLayout Orientation="Horizontal">
+						<Button utu:AutoLayout.PrimaryAlignment="Auto"
 								utu:AutoLayout.CounterAlignment="Center"
-								Content="Filters"
+								Content="Clear filters"
+								Visibility="{Binding HasFilter, Converter={StaticResource TrueToVisible}}"
+								Command="{Binding ResetFilters}"
+								Margin="0,0,8,0"
 								CornerRadius="4"
 								Foreground="{ThemeResource PrimaryBrush}"
 								Style="{StaticResource TextButtonStyle}">
 							<um:ControlExtensions.Icon>
-								<PathIcon Data="{StaticResource Icon_Tune}"
+								<PathIcon Data="{StaticResource Icon_Close}"
 										  Foreground="{ThemeResource PrimaryBrush}" />
 							</um:ControlExtensions.Icon>
 						</Button>
+						<utu:AutoLayout x:Name="FilterButtonHost"
+										DataContext="{Binding Filter}">
+							<Button x:Name="FiltersButton"
+									HorizontalContentAlignment="Center"
+									VerticalContentAlignment="Center"
+									uen:Navigation.Data="{Binding DataContext.Value, ElementName=FilterButtonHost, Mode=TwoWay}"
+									uen:Navigation.Request="!Filter"
+									utu:AutoLayout.CounterAlignment="Center"
+									Content="Filters"
+									CornerRadius="4"
+									Foreground="{ThemeResource PrimaryBrush}"
+									Style="{StaticResource TextButtonStyle}">
+								<um:ControlExtensions.Icon>
+									<PathIcon Data="{StaticResource Icon_Tune}"
+											  Foreground="{ThemeResource PrimaryBrush}" />
+								</um:ControlExtensions.Icon>
+							</Button>
+						</utu:AutoLayout>
 					</utu:AutoLayout>
 				</utu:AutoLayout>
 			</utu:AutoLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#314 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- No way to clear filters directly on the search page - have to first open the filters modal
- No indication on the search page that a filter is applied 

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

https://github.com/unoplatform/uno.chefs/assets/10283398/a5098479-6760-44b8-b172-d96466c2d396

- A Clear filters button now appears on the search page whenever a filter is applied
- It serves both as an indicator that the results are filtered and as a way to clear all filters directly from the search page

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
