### PR TITLE
fix: live cooking steps content is now scrollable on desktop

### DIFF
--- a/src/Chefs/Views/LiveCookingPage.xaml
+++ b/src/Chefs/Views/LiveCookingPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="Chefs.Views.LiveCookingPage"
+<Page x:Class="Chefs.Views.LiveCookingPage"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -30,84 +30,82 @@
 		<utu:AutoLayoutAlignment x:Key="AutoLayoutCenter">Center</utu:AutoLayoutAlignment>
 
 		<DataTemplate x:Key="StepTemplate">
-			<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch"
-							Padding="{utu:Responsive Narrow=32,
-													 Wide=40}"
-							PrimaryAxisAlignment="{utu:Responsive Narrow={StaticResource AutoLayoutStart},
-																  Wide={StaticResource AutoLayoutCenter}}">
-				<ScrollViewer HorizontalScrollMode="Disabled">
-					<utu:AutoLayout Spacing="24">
-						<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-										Orientation="Horizontal">
-							<TextBlock FontSize="22"
-									   FontWeight="SemiBold"
-									   Foreground="{ThemeResource OnSurfaceBrush}"
-									   Style="{StaticResource TitleLarge}"
-									   Text="{Binding Number}"
-									   TextAlignment="Center"
-									   TextWrapping="Wrap" />
-							<TextBlock Margin="0,0,5,0"
-									   FontSize="22"
-									   FontWeight="SemiBold"
-									   Foreground="{ThemeResource OnSurfaceBrush}"
-									   Style="{StaticResource TitleLarge}"
-									   Text="-"
-									   TextAlignment="Center"
-									   TextWrapping="Wrap" />
-							<TextBlock FontSize="22"
-									   FontWeight="SemiBold"
-									   Foreground="{ThemeResource OnSurfaceBrush}"
-									   Style="{StaticResource TitleLarge}"
-									   Text="{Binding Name}"
-									   TextAlignment="Center"
-									   TextWrapping="Wrap" />
-						</utu:AutoLayout>
-						<utu:AutoLayout Padding="16"
-										Background="{ThemeResource BackgroundBrush}"
-										CornerRadius="8"
-										Spacing="16">
-							<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-									   Style="{StaticResource CaptionLarge}"
-									   Text="Ingredients:"
-									   TextAlignment="Center"
-									   TextWrapping="Wrap" />
-							<muxc:ItemsRepeater ItemsSource="{Binding Ingredients}"
-												utu:AutoLayout.PrimaryAlignment="Stretch">
-								<muxc:ItemsRepeater.Layout>
-									<win:LinedFlowLayout ItemsJustification="Center"
-														 MinItemSpacing="16" />
 
-									<not_win:FlowLayout LineAlignment="Center"
-														MinColumnSpacing="16"
-														MinRowSpacing="12" />
-								</muxc:ItemsRepeater.Layout>
-								<muxc:ItemsRepeater.ItemTemplate>
-									<DataTemplate x:DataType="x:String">
-										<utu:AutoLayout Spacing="4"
-														PrimaryAxisAlignment="Center"
-														Orientation="Horizontal">
-											<PathIcon Data="{StaticResource Icon_Check_Circle}"
-													  VerticalAlignment="Center"
-													  Foreground="{ThemeResource OnSurfaceLowBrush}" />
-											<TextBlock Text="{x:Bind}"
-													   VerticalAlignment="Center"
-													   TextWrapping="NoWrap"
-													   Foreground="{ThemeResource OnSurfaceBrush}" />
-										</utu:AutoLayout>
-									</DataTemplate>
-								</muxc:ItemsRepeater.ItemTemplate>
-							</muxc:ItemsRepeater>
-						</utu:AutoLayout>
-						<TextBlock CharacterSpacing="25"
+			<ScrollViewer HorizontalScrollMode="Disabled">
+				<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch"
+								Spacing="24"
+								Padding="{utu:Responsive Narrow=32,
+														 Wide=40}"
+								PrimaryAxisAlignment="{utu:Responsive Narrow={StaticResource AutoLayoutStart},
+																	  Wide={StaticResource AutoLayoutCenter}}">
+					<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+									Orientation="Horizontal">
+						<TextBlock FontSize="22"
+								   FontWeight="SemiBold"
 								   Foreground="{ThemeResource OnSurfaceBrush}"
-								   LineHeight="25"
-								   Style="{StaticResource TitleMedium}"
-								   Text="{Binding Description}"
+								   Style="{StaticResource TitleLarge}"
+								   Text="{Binding Number}"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<TextBlock Margin="0,0,5,0"
+								   FontSize="22"
+								   FontWeight="SemiBold"
+								   Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleLarge}"
+								   Text="-"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<TextBlock FontSize="22"
+								   FontWeight="SemiBold"
+								   Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource TitleLarge}"
+								   Text="{Binding Name}"
 								   TextAlignment="Center"
 								   TextWrapping="Wrap" />
 					</utu:AutoLayout>
-				</ScrollViewer>
-			</utu:AutoLayout>
+					<utu:AutoLayout Padding="16"
+									Background="{ThemeResource BackgroundBrush}"
+									CornerRadius="8"
+									Spacing="16">
+						<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+								   Style="{StaticResource CaptionLarge}"
+								   Text="Ingredients:"
+								   TextAlignment="Center"
+								   TextWrapping="Wrap" />
+						<muxc:ItemsRepeater ItemsSource="{Binding Ingredients}"
+											utu:AutoLayout.PrimaryAlignment="Stretch">
+							<muxc:ItemsRepeater.Layout>
+								<win:LinedFlowLayout ItemsJustification="Center"
+													 MinItemSpacing="16" />
+
+								<not_win:FlowLayout LineAlignment="Center"
+													MinColumnSpacing="16"
+													MinRowSpacing="12" />
+							</muxc:ItemsRepeater.Layout>
+							<muxc:ItemsRepeater.ItemTemplate>
+								<DataTemplate x:DataType="x:String">
+									<utu:AutoLayout Spacing="4"
+													PrimaryAxisAlignment="Center"
+													Orientation="Horizontal">
+										<PathIcon Data="{StaticResource Icon_Check_Circle}"
+												  VerticalAlignment="Center"
+												  Foreground="{ThemeResource OnSurfaceLowBrush}" />
+										<TextBlock Text="{x:Bind}"
+												   VerticalAlignment="Center"
+												   TextWrapping="NoWrap"
+												   Foreground="{ThemeResource OnSurfaceBrush}" />
+									</utu:AutoLayout>
+								</DataTemplate>
+							</muxc:ItemsRepeater.ItemTemplate>
+						</muxc:ItemsRepeater>
+					</utu:AutoLayout>
+					<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+							   Style="{StaticResource TitleMedium}"
+							   Text="{Binding Description}"
+							   TextAlignment="Center"
+							   TextWrapping="Wrap" />
+				</utu:AutoLayout>
+			</ScrollViewer>
 		</DataTemplate>
 	</Page.Resources>
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#267 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/6d47f5f6-975b-45ab-9d2a-af5cc2415049)
Users weren't able to scroll vertically the live cooking steps content on Win/Wasm, only Android worked. They'd have to resize the window to access more content.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/f67f512d-c80a-4871-aa3d-7f8a7efccb01)
Scroll works now on desktop.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
