### PR TITLE
fix: Add number on Page to pipspager

### DIFF
--- a/src/Chefs/Views/WelcomePage.xaml
+++ b/src/Chefs/Views/WelcomePage.xaml
@@ -28,6 +28,7 @@
 				<muxc:PipsPager x:Name="PipsPager"
 								Margin="0,0,0,10"
 								utu:AutoLayout.CounterAlignment="Center"
+								NumberOfPages="3"
 								MaxVisiblePips="3"
 								Orientation="Horizontal"
 								SelectedPageIndex="{Binding NextPage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"


### PR DESCRIPTION
GitHub Issue (If applicable): #

closes unoplatform/uno.chefs-archived#255

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Windows : middle dots stay selected on last page (3) in welcome screen.
Wasm : on 2 dots show on last page in welcom screen.


## What is the new behavior?
3 dots shown and selected acordingly.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
