### PR TITLE
fix: remove static resource on primaryAxisAlignement

### DIFF
--- a/src/Chefs/Views/LiveCookingPage.xaml
+++ b/src/Chefs/Views/LiveCookingPage.xaml
@@ -32,8 +32,8 @@
 								Spacing="24"
 								Padding="{utu:Responsive Narrow=32,
 														 Wide=40}"
-								PrimaryAxisAlignment="{utu:Responsive Narrow={StaticResource AutoLayoutStart},
-																	  Wide={StaticResource AutoLayoutCenter}}">
+								PrimaryAxisAlignment="{utu:Responsive Narrow=Start,
+																	  Wide=Center}">
 					<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
 									Orientation="Horizontal">
 						<TextBlock FontSize="22"


### PR DESCRIPTION
GitHub Issue (If applicable): #

closes unoplatform/uno.chefs-archived#251 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
Content doesn't show in the live cooking page.


## What is the new behavior?
The content is display in the live cooking page.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
Fix crash when navigating to livecooking page on Windows and mobile.

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
