### PR TITLE
fix: reverted PersonPicture workaround

### DIFF
--- a/src/Chefs/Views/HomePage.xaml
+++ b/src/Chefs/Views/HomePage.xaml
@@ -292,13 +292,10 @@
 																	CornerRadius="12"
 																	Padding="10,8"
 																	utu:AutoLayout.CounterAlignment="Center">
-														<Border utu:AutoLayout.CounterAlignment="Center"
-																Width="96"
-																Height="96"
-																CornerRadius="80">
-															<Image Source="{Binding UrlProfileImage}"
-																   Stretch="UniformToFill" />
-														</Border>
+														<PersonPicture utu:AutoLayout.CounterAlignment="Center"
+																	   Width="96"
+																	   Height="96"
+																	   ProfilePicture="{Binding UrlProfileImage}" />
 														<utu:AutoLayout Spacing="4"
 																		PrimaryAxisAlignment="Center">
 															<TextBlock TextAlignment="{utu:Responsive Narrow=Center,

--- a/src/Chefs/Views/ProfilePage.xaml
+++ b/src/Chefs/Views/ProfilePage.xaml
@@ -87,13 +87,10 @@
 						<utu:AutoLayout Spacing="24"
 										Padding="32">
 							<utu:AutoLayout Spacing="16">
-								<Border utu:AutoLayout.CounterAlignment="Center"
-										Width="88"
-										Height="88"
-										CornerRadius="44">
-									<Image Source="{Binding Data.UrlProfileImage}"
-										   Stretch="UniformToFill" />
-								</Border>
+								<PersonPicture utu:AutoLayout.CounterAlignment="Center"
+											   Width="88"
+											   Height="88"
+											   ProfilePicture="{Binding Data.UrlProfileImage}" />
 								<utu:AutoLayout Spacing="4">
 									<TextBlock TextAlignment="Center"
 											   TextWrapping="Wrap"

--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -303,15 +303,10 @@
 																	<utu:AutoLayout Spacing="16"
 																					Padding="16"
 																					Orientation="Horizontal">
-																		<Border Width="60"
-																				Height="60"
-																				CornerRadius="60"
-																				utu:AutoLayout.CounterAlignment="Start">
-																			<Image Source="{Binding UrlAuthorImage}"
-																				   Stretch="UniformToFill"
-																				   HorizontalAlignment="Center"
-																				   VerticalAlignment="Center" />
-																		</Border>
+																		<PersonPicture utu:AutoLayout.CounterAlignment="Start"
+																					   Width="60"
+																					   Height="60"
+																					   ProfilePicture="{Binding UrlAuthorImage}" />
 																		<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start"
 																						utu:AutoLayout.PrimaryAlignment="Stretch">
 																			<utu:AutoLayout Spacing="8"

--- a/src/Chefs/Views/Templates/ItemTemplates.xaml
+++ b/src/Chefs/Views/Templates/ItemTemplates.xaml
@@ -8,16 +8,11 @@
 						Margin="0,8">
 			<utu:AutoLayout Spacing="16"
 							Orientation="Horizontal">
-				<Border utu:AutoLayout.CounterAlignment="Start"
-						Width="60"
-						Height="60"
-						CornerRadius="20"
-						Margin="16,18,0,18">
-					<Image Source="{Binding UrlAuthorImage}"
-						   Stretch="UniformToFill"
-						   VerticalAlignment="Center"
-						   HorizontalAlignment="Center" />
-				</Border>
+				<PersonPicture utu:AutoLayout.CounterAlignment="Start"
+							   Width="60"
+							   Height="60"
+							   ProfilePicture="{Binding UrlAuthorImage}"
+							   Margin="16,18,0,18" />
 				<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start"
 								utu:AutoLayout.PrimaryAlignment="Stretch"
 								Padding="0,18,16,18"


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#335 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PersonPicture replaced by Image within Border as a workaround for unoplatform/uno.chefs-archived#394

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
This PR reverts the workaround implemented for unoplatform/uno.chefs-archived#394 in unoplatform/uno.chefs#716

After the reversal, PersonPicture applied to portraits on the Recipe Details page (creator and reviewers)

win
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/b3a1e4b4-ad32-415c-9944-44e577f0bcb6)
wasm
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/89fc9645-f2a1-44f7-9428-83f15a9a9584)
skia
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/b0c5f482-460c-4edf-92ea-7d4a556178b6)
Android
![image](https://github.com/unoplatform/uno.chefs/assets/10283398/76ed73ce-1cbe-48f6-b0db-4da25bd9d538)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
