### PR TITLE
Transparent icon for wasm

### DIFF
--- a/src/Chefs.Base/base.props
+++ b/src/Chefs.Base/base.props
@@ -27,6 +27,9 @@
 						 ForegroundFile="$(MSBuildThisFileDirectory)Icons\appiconfg-canary.svg"
 						 ForegroundScale="0.5"
 						 Color="#00000000" />
+				<UnoIcon Include="$(MSBuildThisFileDirectory)Icons\appiconfg-canary.svg"
+						 WasmForegroundScale="1"
+						 Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'"/>
 			</ItemGroup>
 		</When>
 		<Otherwise>
@@ -34,8 +37,12 @@
 				<UnoIcon Include="$(MSBuildThisFileDirectory)Icons\iconapp.svg"
 						 ForegroundFile="$(MSBuildThisFileDirectory)Icons\appiconfg.svg"
 						 ForegroundScale="0.5"
-						 Color="#00000000" />
-			</ItemGroup>
+						 Color="#00000000"
+						 Condition="'$(_UnoResizetizerIsWasmApp)' != 'True'"/>
+				<UnoIcon Include="$(MSBuildThisFileDirectory)Icons\appiconfg.svg"
+						 WasmForegroundScale="1"
+						 Condition="'$(_UnoResizetizerIsWasmApp)' == 'True'"/>
+				</ItemGroup>
 		</Otherwise>
 	</Choose>
 


### PR DESCRIPTION
Removing the background svg will make it transparent.

GitHub Issue (If applicable): unoplatform/uno.chefs-archived#351

@silviuo was working on this one and I saw that the limitation was on Resizetizer... After a couple of days of testing how I can support it on Resizetizer I came up with the idea of just deleting the `background` and that works. Not sure if I'll say this the correct way or add some property that will allow that for `.ico` files at least. Also, we can't do that using svg, because svg doesn't know `transparent`.

After PR:
![image](https://github.com/unoplatform/uno.chefs/assets/20712372/f8e752f5-8db6-485d-a0e7-2c13f0065c42)

