### PR TITLE
Avoid allocations during android startup

### DIFF
--- a/src/Chefs.Mobile/Android/Main.Android.cs
+++ b/src/Chefs.Mobile/Android/Main.Android.cs
@@ -21,11 +21,14 @@ public class Application : Microsoft.UI.Xaml.NativeApplication
 
 		// LinkDescription commented for now in the Chefs.Mobile.csproj as it is failing the Android Build
 		// Workaround in place here for System.Collections.Immutable.ImmutableList
-		var unused = ImmutableList.Create<string>();
-		var unused2 = ImmutableList.CreateBuilder<string>();
-		var unused3 = ImmutableList.CreateRange<string>(new string[] { "a", "b" });
-		var unused4 = ImmutableList.Create("a");
-		var unused5 = ImmutableList.Create(new string[] { "a", "b" });
+		if (System.DateTime.Now.Ticks < 0)
+		{
+			var _ = ImmutableList.Create<string>();
+			var _2 = ImmutableList.CreateBuilder<string>();
+			var _3 = ImmutableList.CreateRange<string>(new string[] { "a", "b" });
+			var _4 = ImmutableList.Create("a");
+			var _5 = ImmutableList.Create(new string[] { "a", "b" });
+		}
 	}
 
 	private static void ConfigureUniversalImageLoader()


### PR DESCRIPTION
Just saw a workaround for Android target, and it allocates a couple of collections during startup. This PRs is an attempt to keep the workaround but without executing it during runtime, so we don't have any extra allocation.