### PR TITLE
fix: wrap recipe details in scrollviewer

### DIFF
--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -70,26 +70,27 @@
 				</AppBarButton>
 			</utu:NavigationBar.PrimaryCommands>
 		</utu:NavigationBar>
-		<ScrollViewer HorizontalScrollMode="Disabled"
-					  utu:AutoLayout.PrimaryAlignment="Stretch">
-			<utu:AutoLayout>
-				<utu:AutoLayout Spacing="8"
-								Orientation="Horizontal"
-								Padding="16">
-					<PersonPicture utu:AutoLayout.CounterAlignment="Center"
-								   ProfilePicture="{Binding User.UrlProfileImage}"
-								   Width="32"
-								   Height="32" />
-					<TextBlock Text="{Binding User.FullName, Converter={StaticResource StringFormatter}, ConverterParameter='By {0}'}"
-							   utu:AutoLayout.CounterAlignment="Center"
-							   Foreground="{ThemeResource OnBackgroundMediumBrush}"
-							   Style="{StaticResource BodySmall}" />
-				</utu:AutoLayout>
-				<utu:ResponsiveView Background="{ThemeResource BackgroundBrush}"
-									utu:AutoLayout.PrimaryAlignment="Stretch">
-					<utu:ResponsiveView.NarrowTemplate>
-						<DataTemplate>
-							<utu:AutoLayout>
+
+		<utu:ResponsiveView Background="{ThemeResource BackgroundBrush}"
+							utu:AutoLayout.PrimaryAlignment="Stretch">
+			<utu:ResponsiveView.NarrowTemplate>
+				<DataTemplate>
+					<ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"
+								  HorizontalScrollMode="Disabled">
+						<utu:AutoLayout>
+							<utu:AutoLayout Spacing="8"
+											Orientation="Horizontal"
+											Padding="16">
+								<PersonPicture utu:AutoLayout.CounterAlignment="Center"
+											   ProfilePicture="{Binding User.UrlProfileImage}"
+											   Width="32"
+											   Height="32" />
+								<TextBlock Text="{Binding User.FullName, Converter={StaticResource StringFormatter}, ConverterParameter='By {0}'}"
+										   utu:AutoLayout.CounterAlignment="Center"
+										   Foreground="{ThemeResource OnBackgroundMediumBrush}"
+										   Style="{StaticResource BodySmall}" />
+							</utu:AutoLayout>
+							<utu:AutoLayout Justify="SpaceBetween">
 								<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
 									<utu:AutoLayout Spacing="8"
 													utu:AutoLayout.CounterAlignment="Stretch"
@@ -177,6 +178,7 @@
 															Content="Nutrition"
 															Foreground="{ThemeResource OnSurfaceMediumBrush}" />
 										</utu:TabBar>
+
 										<Grid x:Name="TabNavGrid"
 											  uen:Region.Attached="True"
 											  uen:Region.Navigator="Visibility">
@@ -419,6 +421,7 @@
 												</Grid>
 											</Grid>
 										</Grid>
+
 									</utu:AutoLayout>
 								</utu:AutoLayout>
 								<utu:AutoLayout Height="107"
@@ -433,368 +436,390 @@
 											CornerRadius="4" />
 								</utu:AutoLayout>
 							</utu:AutoLayout>
-						</DataTemplate>
-					</utu:ResponsiveView.NarrowTemplate>
-					<utu:ResponsiveView.WideTemplate>
-						<DataTemplate>
-							<utu:AutoLayout Orientation="Horizontal"
-											utu:AutoLayout.PrimaryAlignment="Stretch">
+						</utu:AutoLayout>
+					</ScrollViewer>
+				</DataTemplate>
+			</utu:ResponsiveView.NarrowTemplate>
+			<utu:ResponsiveView.WideTemplate>
+				<DataTemplate>
+					<utu:AutoLayout>
+						<utu:AutoLayout Spacing="8"
+										Orientation="Horizontal"
+										Padding="16">
+							<PersonPicture utu:AutoLayout.CounterAlignment="Center"
+										   ProfilePicture="{Binding User.UrlProfileImage}"
+										   Width="32"
+										   Height="32" />
+							<TextBlock Text="{Binding User.FullName, Converter={StaticResource StringFormatter}, ConverterParameter='By {0}'}"
+									   utu:AutoLayout.CounterAlignment="Center"
+									   Foreground="{ThemeResource OnBackgroundMediumBrush}"
+									   Style="{StaticResource BodySmall}" />
+						</utu:AutoLayout>
+						<utu:AutoLayout Orientation="Horizontal"
+										utu:AutoLayout.PrimaryAlignment="Stretch">
+
+							<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
 								<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
-									<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
-										<Image Source="{Binding Recipe.ImageUrl}"
-											   Stretch="UniformToFill"
-											   VerticalAlignment="Center"
-											   HorizontalAlignment="Center"
-											   utu:AutoLayout.PrimaryAlignment="Stretch" />
+									<Image Source="{Binding Recipe.ImageUrl}"
+										   Stretch="UniformToFill"
+										   VerticalAlignment="Center"
+										   HorizontalAlignment="Center"
+										   utu:AutoLayout.PrimaryAlignment="Stretch" />
+								</utu:AutoLayout>
+								<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+												CornerRadius="4"
+												Padding="0,16"
+												utu:AutoLayout.IsIndependentLayout="True"
+												Margin="14,14,0,0"
+												VerticalAlignment="Top"
+												HorizontalAlignment="Left"
+												Width="98"
+												Height="317">
+									<utu:AutoLayout Spacing="4"
+													PrimaryAxisAlignment="Center"
+													utu:AutoLayout.PrimaryAlignment="Stretch">
+										<FontIcon Glyph="{StaticResource Icon_Timer}"
+												  utu:AutoLayout.CounterAlignment="Center"
+												  Foreground="{ThemeResource OnSurfaceBrush}" />
+										<TextBlock TextAlignment="Center"
+												   TextWrapping="Wrap"
+												   Text="{Binding Recipe.CookTime, Converter={StaticResource TimeSpanToStringConverter}}"
+												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
+												   Style="{StaticResource BodySmall}" />
 									</utu:AutoLayout>
-									<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-													CornerRadius="4"
-													Padding="0,16"
-													utu:AutoLayout.IsIndependentLayout="True"
-													Margin="14,14,0,0"
-													VerticalAlignment="Top"
-													HorizontalAlignment="Left"
-													Width="98"
-													Height="317">
-										<utu:AutoLayout Spacing="4"
-														PrimaryAxisAlignment="Center"
-														utu:AutoLayout.PrimaryAlignment="Stretch">
-											<FontIcon Glyph="{StaticResource Icon_Timer}"
-													  utu:AutoLayout.CounterAlignment="Center"
-													  Foreground="{ThemeResource OnSurfaceBrush}" />
-											<TextBlock TextAlignment="Center"
-													   TextWrapping="Wrap"
-													   Text="{Binding Recipe.CookTime, Converter={StaticResource TimeSpanToStringConverter}}"
-													   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-													   Style="{StaticResource BodySmall}" />
-										</utu:AutoLayout>
-										<utu:AutoLayout Spacing="4"
-														PrimaryAxisAlignment="Center"
-														utu:AutoLayout.PrimaryAlignment="Stretch">
-											<FontIcon Glyph="{StaticResource Icon_Star_Rate}"
-													  utu:AutoLayout.CounterAlignment="Center"
-													  Foreground="{ThemeResource OnSurfaceBrush}" />
-											<TextBlock TextAlignment="Center"
-													   TextWrapping="Wrap"
-													   Text="{Binding Recipe.Difficulty}"
-													   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-													   Style="{StaticResource BodySmall}" />
-										</utu:AutoLayout>
-										<utu:AutoLayout Spacing="4"
-														PrimaryAxisAlignment="Center"
-														utu:AutoLayout.PrimaryAlignment="Stretch">
-											<FontIcon Glyph="{StaticResource Icon_Local_Fire_Department}"
-													  utu:AutoLayout.CounterAlignment="Center"
-													  Foreground="{ThemeResource OnSurfaceBrush}" />
-											<TextBlock TextAlignment="Center"
-													   TextWrapping="Wrap"
-													   Text="{Binding Recipe.Calories}"
-													   Foreground="{ThemeResource OnSurfaceMediumBrush}"
-													   Style="{StaticResource BodySmall}" />
-										</utu:AutoLayout>
+									<utu:AutoLayout Spacing="4"
+													PrimaryAxisAlignment="Center"
+													utu:AutoLayout.PrimaryAlignment="Stretch">
+										<FontIcon Glyph="{StaticResource Icon_Star_Rate}"
+												  utu:AutoLayout.CounterAlignment="Center"
+												  Foreground="{ThemeResource OnSurfaceBrush}" />
+										<TextBlock TextAlignment="Center"
+												   TextWrapping="Wrap"
+												   Text="{Binding Recipe.Difficulty}"
+												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
+												   Style="{StaticResource BodySmall}" />
+									</utu:AutoLayout>
+									<utu:AutoLayout Spacing="4"
+													PrimaryAxisAlignment="Center"
+													utu:AutoLayout.PrimaryAlignment="Stretch">
+										<FontIcon Glyph="{StaticResource Icon_Local_Fire_Department}"
+												  utu:AutoLayout.CounterAlignment="Center"
+												  Foreground="{ThemeResource OnSurfaceBrush}" />
+										<TextBlock TextAlignment="Center"
+												   TextWrapping="Wrap"
+												   Text="{Binding Recipe.Calories}"
+												   Foreground="{ThemeResource OnSurfaceMediumBrush}"
+												   Style="{StaticResource BodySmall}" />
 									</utu:AutoLayout>
 								</utu:AutoLayout>
-								<utu:AutoLayout x:Name="TabsLayoutWide"
-												uen:Region.Attached="True"
-												Background="{ThemeResource BackgroundBrush}"
-												utu:AutoLayout.PrimaryAlignment="Stretch">
-									<utu:TabBar uen:Region.Attached="True"
-												utu:AutoLayout.CounterAlignment="Center"
-												Margin="40,0"
-												Background="{ThemeResource BackgroundBrush}"
-												Style="{StaticResource TopTabBarStyle}">
-										<utu:TabBarItem uen:Region.Name="IngredientsTabWide"
-														Content="Ingredients"
-														IsSelected="True" />
-										<utu:TabBarItem uen:Region.Name="StepsTabWide"
-														Content="Steps"
-														Foreground="{ThemeResource OnSurfaceMediumBrush}" />
-										<utu:TabBarItem uen:Region.Name="ReviewsTabWide"
-														Content="Reviews"
-														Foreground="{ThemeResource OnSurfaceMediumBrush}" />
-										<utu:TabBarItem uen:Region.Name="NutritionTabWide"
-														Content="Nutrition"
-														Foreground="{ThemeResource OnSurfaceMediumBrush}" />
-									</utu:TabBar>
-									<Grid uen:Region.Attached="True"
-										  uen:Region.Navigator="Visibility">
-										<utu:AutoLayout Spacing="16"
-														Padding="40"
-														uen:Region.Name="IngredientsTabWide">
-											<TextBlock Style="{StaticResource BodyLarge}"
-													   Foreground="{ThemeResource OnSurfaceBrush}"
-													   Text="{Binding Ingredients.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} items'}"
-													   TextWrapping="Wrap" />
-											<uer:FeedView x:Name="IngredientsFeedWide"
-														  Source="{Binding Ingredients}">
-												<DataTemplate>
-													<muxc:ItemsRepeater ItemsSource="{Binding Data}">
-														<muxc:ItemsRepeater.Layout>
-															<muxc:StackLayout Orientation="Vertical"
-																			  Spacing="2" />
-														</muxc:ItemsRepeater.Layout>
-														<muxc:ItemsRepeater.ItemTemplate>
-															<DataTemplate>
-																<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-																				CornerRadius="4"
-																				PrimaryAxisAlignment="Center">
-																	<utu:AutoLayout Spacing="16"
-																					Orientation="Horizontal"
-																					Padding="8,0,16,0">
-																		<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
-																			<utu:AutoLayout Orientation="Horizontal"
-																							utu:AutoLayout.CounterAlignment="Start"
-																							Height="60">
-																				<Image Width="40"
-																					   Source="{Binding UrlIcon}" />
-																			</utu:AutoLayout>
-																		</utu:AutoLayout>
-																		<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
-																						utu:AutoLayout.PrimaryAlignment="Stretch">
-																			<utu:AutoLayout PrimaryAxisAlignment="Center">
-																				<utu:AutoLayout PrimaryAxisAlignment="Center">
-																					<TextBlock TextWrapping="Wrap"
-																							   Text="{Binding Name}"
-																							   Foreground="{ThemeResource OnSurfaceBrush}"
-																							   Style="{StaticResource TitleMedium}" />
+							</utu:AutoLayout>
+							<utu:AutoLayout x:Name="TabsLayoutWide"
+											uen:Region.Attached="True"
+											Background="{ThemeResource BackgroundBrush}"
+											utu:AutoLayout.PrimaryAlignment="Stretch">
+								<utu:TabBar uen:Region.Attached="True"
+											utu:AutoLayout.CounterAlignment="Center"
+											Margin="40,0"
+											Background="{ThemeResource BackgroundBrush}"
+											Style="{StaticResource TopTabBarStyle}">
+									<utu:TabBarItem uen:Region.Name="IngredientsTabWide"
+													Content="Ingredients"
+													IsSelected="True" />
+									<utu:TabBarItem uen:Region.Name="StepsTabWide"
+													Content="Steps"
+													Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+									<utu:TabBarItem uen:Region.Name="ReviewsTabWide"
+													Content="Reviews"
+													Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+									<utu:TabBarItem uen:Region.Name="NutritionTabWide"
+													Content="Nutrition"
+													Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+								</utu:TabBar>
+								<ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"
+											  HorizontalScrollMode="Disabled">
+									<utu:AutoLayout Justify="SpaceBetween">
+										<Grid uen:Region.Attached="True"
+											  uen:Region.Navigator="Visibility"
+											  utu:AutoLayout.PrimaryAlignment="Stretch">
+											<utu:AutoLayout Spacing="16"
+															Padding="40"
+															uen:Region.Name="IngredientsTabWide">
+												<TextBlock Style="{StaticResource BodyLarge}"
+														   Foreground="{ThemeResource OnSurfaceBrush}"
+														   Text="{Binding Ingredients.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} items'}"
+														   TextWrapping="Wrap" />
+												<uer:FeedView x:Name="IngredientsFeedWide"
+															  Source="{Binding Ingredients}">
+													<DataTemplate>
+														<muxc:ItemsRepeater ItemsSource="{Binding Data}">
+															<muxc:ItemsRepeater.Layout>
+																<muxc:StackLayout Orientation="Vertical"
+																				  Spacing="2" />
+															</muxc:ItemsRepeater.Layout>
+															<muxc:ItemsRepeater.ItemTemplate>
+																<DataTemplate>
+																	<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+																					CornerRadius="4"
+																					PrimaryAxisAlignment="Center">
+																		<utu:AutoLayout Spacing="16"
+																						Orientation="Horizontal"
+																						Padding="8,0,16,0">
+																			<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center">
+																				<utu:AutoLayout Orientation="Horizontal"
+																								utu:AutoLayout.CounterAlignment="Start"
+																								Height="60">
+																					<Image Width="40"
+																						   Source="{Binding UrlIcon}" />
 																				</utu:AutoLayout>
 																			</utu:AutoLayout>
-																		</utu:AutoLayout>
-																		<utu:AutoLayout Background="{ThemeResource BackgroundBrush}"
-																						CornerRadius="4"
-																						PrimaryAxisAlignment="End"
-																						Orientation="Horizontal"
-																						Padding="8"
-																						utu:AutoLayout.CounterAlignment="Center">
-																			<utu:AutoLayout PrimaryAxisAlignment="End"
-																							Orientation="Horizontal">
-																				<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start">
-																					<utu:AutoLayout PrimaryAxisAlignment="End"
-																									Orientation="Horizontal"
-																									utu:AutoLayout.CounterAlignment="End">
-																						<TextBlock TextAlignment="End"
-																								   Text="{Binding Quantity}"
-																								   utu:AutoLayout.CounterAlignment="Start"
-																								   Foreground="{ThemeResource OnSecondaryContainerBrush}"
-																								   Style="{StaticResource BodySmall}" />
+																			<utu:AutoLayout utu:AutoLayout.CounterAlignment="Center"
+																							utu:AutoLayout.PrimaryAlignment="Stretch">
+																				<utu:AutoLayout PrimaryAxisAlignment="Center">
+																					<utu:AutoLayout PrimaryAxisAlignment="Center">
+																						<TextBlock TextWrapping="Wrap"
+																								   Text="{Binding Name}"
+																								   Foreground="{ThemeResource OnSurfaceBrush}"
+																								   Style="{StaticResource TitleMedium}" />
+																					</utu:AutoLayout>
+																				</utu:AutoLayout>
+																			</utu:AutoLayout>
+																			<utu:AutoLayout Background="{ThemeResource BackgroundBrush}"
+																							CornerRadius="4"
+																							PrimaryAxisAlignment="End"
+																							Orientation="Horizontal"
+																							Padding="8"
+																							utu:AutoLayout.CounterAlignment="Center">
+																				<utu:AutoLayout PrimaryAxisAlignment="End"
+																								Orientation="Horizontal">
+																					<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start">
+																						<utu:AutoLayout PrimaryAxisAlignment="End"
+																										Orientation="Horizontal"
+																										utu:AutoLayout.CounterAlignment="End">
+																							<TextBlock TextAlignment="End"
+																									   Text="{Binding Quantity}"
+																									   utu:AutoLayout.CounterAlignment="Start"
+																									   Foreground="{ThemeResource OnSecondaryContainerBrush}"
+																									   Style="{StaticResource BodySmall}" />
+																						</utu:AutoLayout>
 																					</utu:AutoLayout>
 																				</utu:AutoLayout>
 																			</utu:AutoLayout>
 																		</utu:AutoLayout>
 																	</utu:AutoLayout>
-																</utu:AutoLayout>
-															</DataTemplate>
-														</muxc:ItemsRepeater.ItemTemplate>
-													</muxc:ItemsRepeater>
-												</DataTemplate>
-											</uer:FeedView>
-										</utu:AutoLayout>
+																</DataTemplate>
+															</muxc:ItemsRepeater.ItemTemplate>
+														</muxc:ItemsRepeater>
+													</DataTemplate>
+												</uer:FeedView>
+											</utu:AutoLayout>
 
-										<utu:AutoLayout Spacing="16"
-														Padding="40"
-														uen:Region.Name="StepsTabWide"
-														Visibility="Collapsed">
-											<TextBlock Style="{StaticResource BodyLarge}"
-													   Foreground="{ThemeResource OnSurfaceBrush}"
-													   Text="{Binding Steps.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} steps'}"
-													   TextWrapping="Wrap" />
-											<uer:FeedView x:Name="StepsFeedWide"
-														  Source="{Binding Steps}">
-												<DataTemplate>
-													<muxc:ItemsRepeater ItemsSource="{Binding Data}">
-														<muxc:ItemsRepeater.Layout>
-															<muxc:StackLayout Orientation="Vertical"
-																			  Spacing="2" />
-														</muxc:ItemsRepeater.Layout>
-														<muxc:ItemsRepeater.ItemTemplate>
-															<DataTemplate>
-																<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-																				CornerRadius="4">
-																	<utu:AutoLayout Orientation="Horizontal"
-																					Padding="16">
-																		<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start"
-																						utu:AutoLayout.PrimaryAlignment="Stretch">
-																			<utu:AutoLayout PrimaryAxisAlignment="Center">
-																				<utu:AutoLayout Spacing="8"
-																								PrimaryAxisAlignment="Center">
-																					<TextBlock TextWrapping="Wrap"
-																							   Text="{Binding Name}"
-																							   Foreground="{ThemeResource OnSurfaceBrush}"
-																							   Style="{StaticResource TitleSmall}" />
-																					<TextBlock TextWrapping="Wrap"
-																							   Text="{Binding Description}"
-																							   Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+											<utu:AutoLayout Spacing="16"
+															Padding="40"
+															uen:Region.Name="StepsTabWide"
+															Visibility="Collapsed">
+												<TextBlock Style="{StaticResource BodyLarge}"
+														   Foreground="{ThemeResource OnSurfaceBrush}"
+														   Text="{Binding Steps.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} steps'}"
+														   TextWrapping="Wrap" />
+												<uer:FeedView x:Name="StepsFeedWide"
+															  Source="{Binding Steps}">
+													<DataTemplate>
+														<muxc:ItemsRepeater ItemsSource="{Binding Data}">
+															<muxc:ItemsRepeater.Layout>
+																<muxc:StackLayout Orientation="Vertical"
+																				  Spacing="2" />
+															</muxc:ItemsRepeater.Layout>
+															<muxc:ItemsRepeater.ItemTemplate>
+																<DataTemplate>
+																	<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+																					CornerRadius="4">
+																		<utu:AutoLayout Orientation="Horizontal"
+																						Padding="16">
+																			<utu:AutoLayout utu:AutoLayout.CounterAlignment="Start"
+																							utu:AutoLayout.PrimaryAlignment="Stretch">
+																				<utu:AutoLayout PrimaryAxisAlignment="Center">
+																					<utu:AutoLayout Spacing="8"
+																									PrimaryAxisAlignment="Center">
+																						<TextBlock TextWrapping="Wrap"
+																								   Text="{Binding Name}"
+																								   Foreground="{ThemeResource OnSurfaceBrush}"
+																								   Style="{StaticResource TitleSmall}" />
+																						<TextBlock TextWrapping="Wrap"
+																								   Text="{Binding Description}"
+																								   Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+																					</utu:AutoLayout>
 																				</utu:AutoLayout>
 																			</utu:AutoLayout>
 																		</utu:AutoLayout>
 																	</utu:AutoLayout>
-																</utu:AutoLayout>
-															</DataTemplate>
-														</muxc:ItemsRepeater.ItemTemplate>
-													</muxc:ItemsRepeater>
-												</DataTemplate>
-											</uer:FeedView>
-										</utu:AutoLayout>
+																</DataTemplate>
+															</muxc:ItemsRepeater.ItemTemplate>
+														</muxc:ItemsRepeater>
+													</DataTemplate>
+												</uer:FeedView>
+											</utu:AutoLayout>
 
-										<utu:AutoLayout Spacing="16"
-														Padding="40"
-														uen:Region.Name="ReviewsTabWide"
-														Visibility="Collapsed">
-											<TextBlock Style="{StaticResource BodyLarge}"
-													   Foreground="{ThemeResource OnSurfaceBrush}"
-													   Text="{Binding Reviews.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} comments'}"
-													   TextWrapping="Wrap"
-													   Visibility="{Binding Reviews.Count, Converter={StaticResource GreaterThanZeroToVisibleConverter}}" />
+											<utu:AutoLayout Spacing="16"
+															Padding="40"
+															uen:Region.Name="ReviewsTabWide"
+															Visibility="Collapsed">
+												<TextBlock Style="{StaticResource BodyLarge}"
+														   Foreground="{ThemeResource OnSurfaceBrush}"
+														   Text="{Binding Reviews.Count, Converter={StaticResource StringFormatter}, ConverterParameter='{}{0} comments'}"
+														   TextWrapping="Wrap"
+														   Visibility="{Binding Reviews.Count, Converter={StaticResource GreaterThanZeroToVisibleConverter}}" />
 
-											<uer:FeedView x:Name="ReviewsFeedWide"
-														  VerticalContentAlignment="Center"
-														  NoneTemplate="{StaticResource EmptyTemplate}"
-														  Source="{Binding Reviews}">
-												<DataTemplate>
-													<muxc:ItemsRepeater ItemsSource="{Binding Data}">
-														<muxc:ItemsRepeater.Layout>
-															<muxc:StackLayout Orientation="Vertical"
-																			  Spacing="2" />
-														</muxc:ItemsRepeater.Layout>
-														<muxc:ItemsRepeater.ItemTemplate>
-															<DataTemplate>
+												<uer:FeedView x:Name="ReviewsFeedWide"
+															  VerticalContentAlignment="Center"
+															  NoneTemplate="{StaticResource EmptyTemplate}"
+															  Source="{Binding Reviews}">
+													<DataTemplate>
+														<muxc:ItemsRepeater ItemsSource="{Binding Data}">
+															<muxc:ItemsRepeater.Layout>
+																<muxc:StackLayout Orientation="Vertical"
+																				  Spacing="2" />
+															</muxc:ItemsRepeater.Layout>
+															<muxc:ItemsRepeater.ItemTemplate>
+																<DataTemplate>
 
-																<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-																				Spacing="16"
-																				CornerRadius="4"
-																				Orientation="Horizontal"
-																				Padding="16">
-																	<PersonPicture utu:AutoLayout.CounterAlignment="Start"
-																				   Width="60"
-																				   Height="60"
-																				   ProfilePicture="{Binding UrlAuthorImage}" />
-																	<utu:AutoLayout Spacing="8"
-																					utu:AutoLayout.CounterAlignment="Start"
-																					utu:AutoLayout.PrimaryAlignment="Stretch">
-																		<TextBlock TextWrapping="Wrap"
-																				   Text="{Binding Description}"
-																				   Foreground="{ThemeResource OnSurfaceBrush}" />
-																		<TextBlock TextWrapping="Wrap"
-																				   Text="{Binding PublisherName}"
-																				   Foreground="{ThemeResource OnSurfaceMediumBrush}" />
-																		<utu:AutoLayout Spacing="24"
-																						Orientation="Horizontal"
-																						Padding="0,16,0,0">
-																			<utu:AutoLayout Orientation="Horizontal"
-																							utu:AutoLayout.CounterAlignment="Start">
-																				<ToggleButton HorizontalContentAlignment="Center"
-																							  VerticalContentAlignment="Center"
-																							  utu:AutoLayout.CounterAlignment="Center"
-																							  Command="{utu:AncestorBinding AncestorType=uer:FeedView,
-																															Path=DataContext.Like}"
-																							  CommandParameter="{Binding}"
-																							  IsChecked="{Binding UserLike, Converter={StaticResource UserLikeCheckedConverter}}">
-																					<ToggleButton.Content>
-																						<utu:AutoLayout Orientation="Horizontal"
-																										Spacing="8">
-																							<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Off_Alt}"
-																									  VerticalAlignment="Center"
-																									  Foreground="{ThemeResource PrimaryBrush}" />
-																							<TextBlock Text="{Binding Likes.Count}"
-																									   utu:AutoLayout.CounterAlignment="Center"
-																									   Foreground="{ThemeResource PrimaryBrush}"
-																									   Style="{StaticResource LabelLarge}" />
-																						</utu:AutoLayout>
-																					</ToggleButton.Content>
-																					<um:ControlExtensions.AlternateContent>
-																						<utu:AutoLayout Orientation="Horizontal"
-																										Spacing="8">
-																							<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Alt}"
-																									  VerticalAlignment="Center"
-																									  Foreground="{ThemeResource PrimaryBrush}" />
-																							<TextBlock Text="{Binding Likes.Count}"
-																									   utu:AutoLayout.CounterAlignment="Center"
-																									   Foreground="{ThemeResource PrimaryBrush}"
-																									   Style="{StaticResource LabelLarge}" />
-																						</utu:AutoLayout>
-																					</um:ControlExtensions.AlternateContent>
-																				</ToggleButton>
-																			</utu:AutoLayout>
-																			<utu:AutoLayout Orientation="Horizontal"
-																							utu:AutoLayout.CounterAlignment="Start">
-																				<ToggleButton HorizontalContentAlignment="Center"
-																							  VerticalContentAlignment="Center"
-																							  utu:AutoLayout.CounterAlignment="Center"
-																							  Command="{utu:AncestorBinding AncestorType=uer:FeedView,
-																															Path=DataContext.Dislike}"
-																							  CommandParameter="{Binding}"
-																							  IsChecked="{Binding UserLike, Converter={StaticResource UserDislikeCheckedConverter}}">
-																					<ToggleButton.Content>
-																						<utu:AutoLayout Orientation="Horizontal"
-																										Spacing="8">
-																							<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Off_Alt}"
-																									  VerticalAlignment="Center"
-																									  Foreground="{ThemeResource PrimaryBrush}" />
-																							<TextBlock Text="{Binding Dislikes.Count}"
-																									   utu:AutoLayout.CounterAlignment="Center"
-																									   Foreground="{ThemeResource PrimaryBrush}"
-																									   Style="{StaticResource LabelLarge}" />
-																						</utu:AutoLayout>
-																					</ToggleButton.Content>
-																					<um:ControlExtensions.AlternateContent>
-																						<utu:AutoLayout Orientation="Horizontal"
-																										Spacing="8">
-																							<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Alt}"
-																									  VerticalAlignment="Center"
-																									  Foreground="{ThemeResource PrimaryBrush}" />
-																							<TextBlock Text="{Binding Dislikes.Count}"
-																									   utu:AutoLayout.CounterAlignment="Center"
-																									   Foreground="{ThemeResource PrimaryBrush}"
-																									   Style="{StaticResource LabelLarge}" />
-																						</utu:AutoLayout>
-																					</um:ControlExtensions.AlternateContent>
-																				</ToggleButton>
+																	<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+																					Spacing="16"
+																					CornerRadius="4"
+																					Orientation="Horizontal"
+																					Padding="16">
+																		<PersonPicture utu:AutoLayout.CounterAlignment="Start"
+																					   Width="60"
+																					   Height="60"
+																					   ProfilePicture="{Binding UrlAuthorImage}" />
+																		<utu:AutoLayout Spacing="8"
+																						utu:AutoLayout.CounterAlignment="Start"
+																						utu:AutoLayout.PrimaryAlignment="Stretch">
+																			<TextBlock TextWrapping="Wrap"
+																					   Text="{Binding Description}"
+																					   Foreground="{ThemeResource OnSurfaceBrush}" />
+																			<TextBlock TextWrapping="Wrap"
+																					   Text="{Binding PublisherName}"
+																					   Foreground="{ThemeResource OnSurfaceMediumBrush}" />
+																			<utu:AutoLayout Spacing="24"
+																							Orientation="Horizontal"
+																							Padding="0,16,0,0">
+																				<utu:AutoLayout Orientation="Horizontal"
+																								utu:AutoLayout.CounterAlignment="Start">
+																					<ToggleButton HorizontalContentAlignment="Center"
+																								  VerticalContentAlignment="Center"
+																								  utu:AutoLayout.CounterAlignment="Center"
+																								  Command="{utu:AncestorBinding AncestorType=uer:FeedView,
+																																Path=DataContext.Like}"
+																								  CommandParameter="{Binding}"
+																								  IsChecked="{Binding UserLike, Converter={StaticResource UserLikeCheckedConverter}}">
+																						<ToggleButton.Content>
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="8">
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Off_Alt}"
+																										  VerticalAlignment="Center"
+																										  Foreground="{ThemeResource PrimaryBrush}" />
+																								<TextBlock Text="{Binding Likes.Count}"
+																										   utu:AutoLayout.CounterAlignment="Center"
+																										   Foreground="{ThemeResource PrimaryBrush}"
+																										   Style="{StaticResource LabelLarge}" />
+																							</utu:AutoLayout>
+																						</ToggleButton.Content>
+																						<um:ControlExtensions.AlternateContent>
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="8">
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Alt}"
+																										  VerticalAlignment="Center"
+																										  Foreground="{ThemeResource PrimaryBrush}" />
+																								<TextBlock Text="{Binding Likes.Count}"
+																										   utu:AutoLayout.CounterAlignment="Center"
+																										   Foreground="{ThemeResource PrimaryBrush}"
+																										   Style="{StaticResource LabelLarge}" />
+																							</utu:AutoLayout>
+																						</um:ControlExtensions.AlternateContent>
+																					</ToggleButton>
+																				</utu:AutoLayout>
+																				<utu:AutoLayout Orientation="Horizontal"
+																								utu:AutoLayout.CounterAlignment="Start">
+																					<ToggleButton HorizontalContentAlignment="Center"
+																								  VerticalContentAlignment="Center"
+																								  utu:AutoLayout.CounterAlignment="Center"
+																								  Command="{utu:AncestorBinding AncestorType=uer:FeedView,
+																																Path=DataContext.Dislike}"
+																								  CommandParameter="{Binding}"
+																								  IsChecked="{Binding UserLike, Converter={StaticResource UserDislikeCheckedConverter}}">
+																						<ToggleButton.Content>
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="8">
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Off_Alt}"
+																										  VerticalAlignment="Center"
+																										  Foreground="{ThemeResource PrimaryBrush}" />
+																								<TextBlock Text="{Binding Dislikes.Count}"
+																										   utu:AutoLayout.CounterAlignment="Center"
+																										   Foreground="{ThemeResource PrimaryBrush}"
+																										   Style="{StaticResource LabelLarge}" />
+																							</utu:AutoLayout>
+																						</ToggleButton.Content>
+																						<um:ControlExtensions.AlternateContent>
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="8">
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Alt}"
+																										  VerticalAlignment="Center"
+																										  Foreground="{ThemeResource PrimaryBrush}" />
+																								<TextBlock Text="{Binding Dislikes.Count}"
+																										   utu:AutoLayout.CounterAlignment="Center"
+																										   Foreground="{ThemeResource PrimaryBrush}"
+																										   Style="{StaticResource LabelLarge}" />
+																							</utu:AutoLayout>
+																						</um:ControlExtensions.AlternateContent>
+																					</ToggleButton>
+																				</utu:AutoLayout>
 																			</utu:AutoLayout>
 																		</utu:AutoLayout>
 																	</utu:AutoLayout>
-																</utu:AutoLayout>
-															</DataTemplate>
-														</muxc:ItemsRepeater.ItemTemplate>
-													</muxc:ItemsRepeater>
-												</DataTemplate>
-											</uer:FeedView>
-										</utu:AutoLayout>
+																</DataTemplate>
+															</muxc:ItemsRepeater.ItemTemplate>
+														</muxc:ItemsRepeater>
+													</DataTemplate>
+												</uer:FeedView>
+											</utu:AutoLayout>
 
-										<Grid uen:Region.Name="NutritionTabWide"
-											  Visibility="Collapsed">
-											<Grid Margin="40"
-												  Padding="24"
-												  Background="{ThemeResource SurfaceColor}"
-												  CornerRadius="24"
-												  RowSpacing="24">
-												<Grid.RowDefinitions>
-													<RowDefinition Height="Auto" />
-													<RowDefinition Height="Auto" />
-												</Grid.RowDefinitions>
-												<TextBlock TextAlignment="Center"
-														   Text="Intake per serving"
-														   Foreground="{ThemeResource OnBackgroundBrush}"
-														   Style="{StaticResource TitleLarge}" />
+											<Grid uen:Region.Name="NutritionTabWide"
+												  Visibility="Collapsed">
+												<Grid Margin="40"
+													  Padding="24"
+													  Background="{ThemeResource SurfaceColor}"
+													  CornerRadius="24"
+													  RowSpacing="24">
+													<Grid.RowDefinitions>
+														<RowDefinition Height="Auto" />
+														<RowDefinition Height="Auto" />
+													</Grid.RowDefinitions>
+													<TextBlock TextAlignment="Center"
+															   Text="Intake per serving"
+															   Foreground="{ThemeResource OnBackgroundBrush}"
+															   Style="{StaticResource TitleLarge}" />
 
-												<ctrl:ChartControl DataContext="{Binding Recipe}"
-																   Grid.Row="1" />
+													<ctrl:ChartControl DataContext="{Binding Recipe}"
+																	   Grid.Row="1" />
+												</Grid>
 											</Grid>
 										</Grid>
-									</Grid>
-									<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
-													Padding="40,24">
-										<Button Content="Start Cooking!"
-												Command="{Binding LiveCooking}"
-												Padding="24,20"
-												Height="59"
-												CornerRadius="4" />
+										<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
+														Padding="40,24">
+											<Button Content="Start Cooking!"
+													Command="{Binding LiveCooking}"
+													Padding="24,20"
+													Height="59"
+													CornerRadius="4" />
+										</utu:AutoLayout>
 									</utu:AutoLayout>
-								</utu:AutoLayout>
+								</ScrollViewer>
+
 							</utu:AutoLayout>
-						</DataTemplate>
-					</utu:ResponsiveView.WideTemplate>
-				</utu:ResponsiveView>
-			</utu:AutoLayout>
-		</ScrollViewer>
+						</utu:AutoLayout>
+					</utu:AutoLayout>
+				</DataTemplate>
+			</utu:ResponsiveView.WideTemplate>
+		</utu:ResponsiveView>
 	</utu:AutoLayout>
 </Page>


### PR DESCRIPTION
closes unoplatform/uno.chefs-archived#246 

Before|After
-|-
![scrolldetailsbad](https://github.com/unoplatform/uno.chefs/assets/4793020/9137cdbe-efe7-4c2d-b4c9-0b6632646bf0)|![scrolldetails](https://github.com/unoplatform/uno.chefs/assets/4793020/25d2853e-d397-4abb-a766-33e836549940)
