### PR TITLE
fix: Replace PathIcon for FontIcon in Cookbook tab

### DIFF
--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -135,6 +135,7 @@
 													Visibility="{Binding CookbookImages.ThirdImage, Converter={StaticResource NullToVisible}}">
 												<Button.Content>
 													<FontIcon Glyph="{StaticResource Icon_Add}"
+															  FontFamily="{StaticResource MaterialIconFontFamily}"
 															  Foreground="{ThemeResource OnSurfaceBrush}" />
 												</Button.Content>
 											</Button>
@@ -359,6 +360,7 @@
 										Style="{StaticResource FabStyle}">
 									<um:ControlExtensions.Icon>
 										<FontIcon Glyph="{StaticResource Icon_Add}"
+												  FontFamily="{StaticResource MaterialIconFontFamily}"
 												  Foreground="{ThemeResource OnPrimaryBrush}" />
 									</um:ControlExtensions.Icon>
 								</Button>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#244

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

Replace `PathIcon` for `FontIcon` in FavoriteRecipePage/CookBookTemplate
- Bugfix
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
`PathIcon` causing crash/render problems.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
`FontIcon` in place.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
