### PR TITLE
fix: placeholder text in the passwordbox does not match current theme

### DIFF
--- a/src/Chefs/Views/LoginPage.xaml
+++ b/src/Chefs/Views/LoginPage.xaml
@@ -23,7 +23,7 @@
 				<ResourceDictionary x:Key="Light">
 					<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceMediumBrush" />
 					<!-- Workaround for winui/windows -->
-					<x:String x:Key="WorkAroundDummy">WorkAroundDummy</x:String>					
+					<x:String x:Key="WorkAroundDummy">WorkAroundDummy</x:String>
 				</ResourceDictionary>
 				<ResourceDictionary x:Key="Default">
 					<StaticResource x:Key="OutlinedPasswordBoxPlaceholderForeground" ResourceKey="OnSurfaceMediumBrush" />


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#242 

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
PlaceHolderText will always default to using the system default theme instead of the app theme. Due to known issue with resource dictionary and windows ([read more here](https://stackoverflow.com/questions/44266369/xaml-resourcedictionary-not-loading-correctly-with-a-single-keyset))

## What is the new behavior?
Workaround implemented with dummy string so that the PlaceholderText in PasswordBox now matches the correct theme color scheme

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
