### PR TITLE
fix: replace material with fa thumbs icon

### DIFF
--- a/src/Chefs/Styles/Strings.xaml
+++ b/src/Chefs/Styles/Strings.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<!--#region: Material Icon Font Glyphs-->
 	<x:String x:Key="Icon_Home">&#xe9b2;</x:String>
@@ -36,5 +36,7 @@
 	<x:String x:Key="Icon_Favorite">&#xf004;</x:String>
 	<x:String x:Key="Icon_Apple_Brand">&#xf179;</x:String>
 	<x:String x:Key="Icon_Google_Brand">&#xf1a0;</x:String>
+	<x:String x:Key="Icon_Thumb_Up">&#xf164;</x:String>
+	<x:String x:Key="Icon_Thumb_Down">&#xf165;</x:String>
 	<!--#endregion-->
 </ResourceDictionary>

--- a/src/Chefs/Views/RecipeDetailsPage.xaml
+++ b/src/Chefs/Views/RecipeDetailsPage.xaml
@@ -338,26 +338,30 @@
 																								  CommandParameter="{Binding}"
 																								  IsChecked="{Binding UserLike, Converter={StaticResource UserLikeCheckedConverter}}">
 																						<ToggleButton.Content>
-																							<StackPanel Orientation="Horizontal">
-																								<FontIcon Margin="0,0,5,0"
-																										  VerticalAlignment="Center"
-																										  Glyph="{StaticResource Icon_Thumb_Up_Off_Alt}"
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="5">
+																								<FontIcon FontSize="20"
+																										  utu:AutoLayout.CounterAlignment="Center"
+																										  Glyph="{StaticResource Icon_Thumb_Up}"
+																										  Style="{StaticResource FontAwesomeRegularFontIconStyle}"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
-																								<TextBlock VerticalAlignment="Center"
+																								<TextBlock utu:AutoLayout.CounterAlignment="Center"
 																										   Foreground="{ThemeResource PrimaryBrush}"
 																										   Text="{Binding Likes.Count}" />
-																							</StackPanel>
+																							</utu:AutoLayout>
 																						</ToggleButton.Content>
 																						<ut:ControlExtensions.AlternateContent>
-																							<StackPanel Orientation="Horizontal">
-																								<FontIcon Margin="0,0,5,0"
-																										  VerticalAlignment="Center"
-																										  Glyph="{StaticResource Icon_Thumb_Up_Alt}"
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="5">
+																								<FontIcon FontSize="20"
+																										  utu:AutoLayout.CounterAlignment="Center"
+																										  Glyph="{StaticResource Icon_Thumb_Up}"
+																										  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
-																								<TextBlock VerticalAlignment="Center"
+																								<TextBlock utu:AutoLayout.CounterAlignment="Center"
 																										   Foreground="{ThemeResource PrimaryBrush}"
 																										   Text="{Binding Likes.Count}" />
-																							</StackPanel>
+																							</utu:AutoLayout>
 																						</ut:ControlExtensions.AlternateContent>
 																					</ToggleButton>
 																					<ToggleButton HorizontalContentAlignment="Center"
@@ -368,26 +372,30 @@
 																								  CommandParameter="{Binding}"
 																								  IsChecked="{Binding UserLike, Converter={StaticResource UserDislikeCheckedConverter}}">
 																						<ToggleButton.Content>
-																							<StackPanel Orientation="Horizontal">
-																								<FontIcon Margin="0,0,5,0"
-																										  VerticalAlignment="Center"
-																										  Glyph="{StaticResource Icon_Thumb_Down_Off_Alt}"
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="5">
+																								<FontIcon FontSize="20"
+																										  utu:AutoLayout.CounterAlignment="Center"
+																										  Glyph="{StaticResource Icon_Thumb_Down}"
+																										  Style="{StaticResource FontAwesomeRegularFontIconStyle}"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
-																								<TextBlock VerticalAlignment="Center"
+																								<TextBlock utu:AutoLayout.CounterAlignment="Center"
 																										   Foreground="{ThemeResource PrimaryBrush}"
 																										   Text="{Binding Dislikes.Count}" />
-																							</StackPanel>
+																							</utu:AutoLayout>
 																						</ToggleButton.Content>
 																						<ut:ControlExtensions.AlternateContent>
-																							<StackPanel Orientation="Horizontal">
-																								<FontIcon Margin="0,0,5,0"
-																										  VerticalAlignment="Center"
-																										  Glyph="{StaticResource Icon_Thumb_Down_Alt}"
+																							<utu:AutoLayout Orientation="Horizontal"
+																											Spacing="5">
+																								<FontIcon FontSize="20"
+																										  utu:AutoLayout.CounterAlignment="Center"
+																										  Glyph="{StaticResource Icon_Thumb_Down}"
+																										  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
-																								<TextBlock VerticalAlignment="Center"
+																								<TextBlock utu:AutoLayout.CounterAlignment="Center"
 																										   Foreground="{ThemeResource PrimaryBrush}"
 																										   Text="{Binding Dislikes.Count}" />
-																							</StackPanel>
+																							</utu:AutoLayout>
 																						</ut:ControlExtensions.AlternateContent>
 																					</ToggleButton>
 																				</utu:AutoLayout>
@@ -715,8 +723,10 @@
 																						<ToggleButton.Content>
 																							<utu:AutoLayout Orientation="Horizontal"
 																											Spacing="8">
-																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Off_Alt}"
-																										  VerticalAlignment="Center"
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up}"
+																										  FontSize="20"
+																										  Style="{StaticResource FontAwesomeRegularFontIconStyle}"
+																										  utu:AutoLayout.CounterAlignment="Center"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
 																								<TextBlock Text="{Binding Likes.Count}"
 																										   utu:AutoLayout.CounterAlignment="Center"
@@ -727,8 +737,10 @@
 																						<ut:ControlExtensions.AlternateContent>
 																							<utu:AutoLayout Orientation="Horizontal"
 																											Spacing="8">
-																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up_Alt}"
-																										  VerticalAlignment="Center"
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Up}"
+																										  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
+																										  FontSize="20"
+																										  utu:AutoLayout.CounterAlignment="Center"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
 																								<TextBlock Text="{Binding Likes.Count}"
 																										   utu:AutoLayout.CounterAlignment="Center"
@@ -750,8 +762,10 @@
 																						<ToggleButton.Content>
 																							<utu:AutoLayout Orientation="Horizontal"
 																											Spacing="8">
-																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Off_Alt}"
-																										  VerticalAlignment="Center"
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down}"
+																										  FontSize="20"
+																										  Style="{StaticResource FontAwesomeRegularFontIconStyle}"
+																										  utu:AutoLayout.CounterAlignment="Center"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
 																								<TextBlock Text="{Binding Dislikes.Count}"
 																										   utu:AutoLayout.CounterAlignment="Center"
@@ -762,8 +776,10 @@
 																						<ut:ControlExtensions.AlternateContent>
 																							<utu:AutoLayout Orientation="Horizontal"
 																											Spacing="8">
-																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down_Alt}"
-																										  VerticalAlignment="Center"
+																								<FontIcon Glyph="{StaticResource Icon_Thumb_Down}"
+																										  FontSize="20"
+																										  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
+																										  utu:AutoLayout.CounterAlignment="Center"
 																										  Foreground="{ThemeResource PrimaryBrush}" />
 																								<TextBlock Text="{Binding Dislikes.Count}"
 																										   utu:AutoLayout.CounterAlignment="Center"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#215 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Material solid thumb not available

<img width="216" alt="outlinedThumbs" src="https://github.com/unoplatform/uno.chefs/assets/34275909/7a7ee4d3-2799-46da-a606-c413c5f965a5">


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

replaced by Font awesome thumb icon

<img width="123" alt="newThumbs" src="https://github.com/unoplatform/uno.chefs/assets/34275909/83383582-440f-4c9a-81f5-223b7db45cc3">


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
