### PR TITLE
fix: Night Mode toggle updated on app launch

### DIFF
--- a/src/Chefs/App.cs
+++ b/src/Chefs/App.cs
@@ -71,6 +71,7 @@ public class App : Application
 		Host = await builder.NavigateAsync<ShellControl>();
 
 		var config = Host.Services.GetRequiredService<IOptions<AppConfig>>();
+		var userService = Host.Services.GetRequiredService<IUserService>();
 		var themeService = _window.GetThemeService();
 		var appTheme = config.Value?.IsDark switch
 		{
@@ -79,6 +80,7 @@ public class App : Application
 			_ => AppTheme.System
 		};
 
+		await userService.UpdateSettings(CancellationToken.None, isDark: themeService.IsDark);
 		await themeService.SetThemeAsync(appTheme);
 	}
 

--- a/src/Chefs/Services/Users/IUserService.cs
+++ b/src/Chefs/Services/Users/IUserService.cs
@@ -69,6 +69,18 @@ public interface IUserService
 	/// </returns>
 	Task SetSettings(AppConfig chefSettings, CancellationToken ct);
 
+	///<summary>
+	/// Update app settings with specified properties without overwriting the rest
+	/// </summary>
+	/// <param name="ct"></param>
+	/// <param name="title">App title</param>
+	/// <param name="isDark">App theme flag</param>
+	/// <param name="notification">User notifications flag</param>
+	/// <param name="accentColor">Accent color</param>
+	/// <returns>
+	/// </returns>
+	Task UpdateSettings(CancellationToken ct, string? title = null, bool? isDark = null, bool? notification = null, string? accentColor = null);
+
 	// <summary>
 	// Authentication method
 	// </summary>

--- a/src/Chefs/Services/Users/UserService.cs
+++ b/src/Chefs/Services/Users/UserService.cs
@@ -32,6 +32,7 @@ public class UserService : IUserService
 	{
 		var settings = new AppConfig
 		{
+			Title = chefSettings.Title,
 			IsDark = chefSettings.IsDark,
 			Notification = chefSettings.Notification,
 			AccentColor = chefSettings.AccentColor,
@@ -39,6 +40,21 @@ public class UserService : IUserService
 
 		await _chefAppOptions.UpdateAsync(_ => settings);
 		await Settings.UpdateAsync(_ => settings, ct);
+	}
+
+	public async Task UpdateSettings(CancellationToken ct, string? title = null, bool? isDark = null, bool? notification = null, string? accentColor = null)
+	{
+		var currentSettings = await GetSettings(ct);
+
+		var settings = new AppConfig
+		{
+			Title = title ?? currentSettings.Title,
+			IsDark = isDark ?? currentSettings.IsDark,
+			Notification = notification ?? currentSettings.Notification,
+			AccentColor = accentColor ?? currentSettings.AccentColor,
+		};
+
+		await SetSettings(settings, ct);
 	}
 
 	public async ValueTask<User> GetById(Guid userId, CancellationToken ct)


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#249

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With a default dark theme on windows the app launches in dark mode. However the toggle still shows light mode on fresh install until it gets toggled once.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
The theme is now updated in the settings on app launch, so the state of the toggle shows up correctly in the Settings.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
