### PR TITLE
fix: set solid fav icon when tapped on create/update cookbook

### DIFF
--- a/src/Chefs/Converters/Converters.xaml
+++ b/src/Chefs/Converters/Converters.xaml
@@ -43,16 +43,6 @@
 										NullValue="PrimaryMediumBrush"
 										TrueValue="PrimaryBrush" />
 
-	<converters:BoolToResourceConverter x:Key="IsCreatingCookbookFavoriteToColorConverter"
-										FalseValue="PrimaryBrush"
-										TrueValue="OnSurfaceMediumBrush"
-										NullValue="OnSurfaceMediumBrush" />
-
-	<converters:BoolToResourceConverter x:Key="IsCreatingCookbookFavoriteBorderToColorConverter"
-										FalseValue="OnSurfaceBrush"
-										TrueValue="OnSurfaceMediumBrush"
-										NullValue="OnSurfaceMediumBrush" />
-
 	<converters:BoolToResourceConverter x:Key="UserDislikeColorConverter"
 										FalseValue="PrimaryBrush"
 										NullValue="PrimaryMediumBrush"

--- a/src/Chefs/Styles/Strings.xaml
+++ b/src/Chefs/Styles/Strings.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<!--#region: Material Icon Font Glyphs-->
 	<x:String x:Key="Icon_Home">&#xe9b2;</x:String>

--- a/src/Chefs/Views/CookbookDetailPage.xaml
+++ b/src/Chefs/Views/CookbookDetailPage.xaml
@@ -129,7 +129,7 @@
 				CornerRadius="60"
 				Style="{StaticResource FabStyle}">
 			<ut:ControlExtensions.Icon>
-				<FontIcon Glyph="{StaticResource Icon_Add}"
+				<FontIcon Glyph="{StaticResource Icon_Edit}"
 						  Foreground="{ThemeResource SurfaceBrush}" />
 			</ut:ControlExtensions.Icon>
 		</Button>

--- a/src/Chefs/Views/CreateUpdateCookbookPage.xaml
+++ b/src/Chefs/Views/CreateUpdateCookbookPage.xaml
@@ -89,14 +89,14 @@
 														<FontIcon Style="{StaticResource FontAwesomeRegularFontIconStyle}"
 																  Glyph="{StaticResource Icon_Favorite}"
 																  DataContext="{utu:AncestorBinding AncestorType=uer:FeedView}"
-																  Foreground="{Binding DataContext.IsCreate, Converter={StaticResource IsCreatingCookbookFavoriteBorderToColorConverter}}" />
+																  Foreground="{ThemeResource OnSurfaceBrush}" />
 													</Border>
 													<Border utu:AutoLayout.CounterAlignment="Start"
 															Visibility="{Binding Selected, Converter={StaticResource TrueToVisible}}">
 														<FontIcon Style="{StaticResource FontAwesomeSolidFontIconStyle}"
 																  Glyph="{StaticResource Icon_Favorite}"
 																  DataContext="{utu:AncestorBinding AncestorType=uer:FeedView}"
-																  Foreground="{Binding DataContext.IsCreate, Converter={StaticResource IsCreatingCookbookFavoriteToColorConverter}}" />
+																  Foreground="{ThemeResource PrimaryBrush}" />
 													</Border>
 												</utu:AutoLayout>
 											</utu:AutoLayout>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#212 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
favorite icon is not changing when tapping

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
![fav-icon-solid](https://github.com/unoplatform/uno.chefs/assets/34275909/86b92995-90bc-4d99-b5e2-27b982c3252d)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
