### PR TITLE
fix: add button color in cookbook details page

### DIFF
--- a/src/Chefs/AppResources.xaml
+++ b/src/Chefs/AppResources.xaml
@@ -16,6 +16,20 @@
 		<ResourceDictionary Source="ms-appx:///Chefs/Styles/Strings.xaml" />
 		<ResourceDictionary Source="ms-appx:///Chefs/Styles/CustomFonts.xaml" />
 		<ResourceDictionary Source="ms-appx:///Chefs/Styles/Images.xaml" />
+		<ResourceDictionary>
+			<ResourceDictionary.ThemeDictionaries>
+				<ResourceDictionary x:Key="Light">
+					<StaticResource x:Key="FabBackground" ResourceKey="PrimaryBrush" />
+					<StaticResource x:Key="FabBackgroundPressed" ResourceKey="PrimaryBrush" />
+					<StaticResource x:Key="FabBackgroundPointerOver" ResourceKey="PrimaryBrush" />
+				</ResourceDictionary>
+				<ResourceDictionary x:Key="Dark">
+					<StaticResource x:Key="FabBackground" ResourceKey="PrimaryBrush" />
+					<StaticResource x:Key="FabBackgroundPressed" ResourceKey="PrimaryBrush" />
+					<StaticResource x:Key="FabBackgroundPointerOver" ResourceKey="PrimaryBrush" />
+				</ResourceDictionary>
+			</ResourceDictionary.ThemeDictionaries>
+		</ResourceDictionary>
 
 	</ResourceDictionary.MergedDictionaries>
 

--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -355,7 +355,6 @@
 										VerticalAlignment="Bottom"
 										uen:Navigation.Request="!CreateCookbook"
 										utu:AutoLayout.IsIndependentLayout="True"
-										Background="{ThemeResource PrimaryBrush}"
 										CornerRadius="56"
 										Style="{StaticResource FabStyle}">
 									<ut:ControlExtensions.Icon>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#210

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Changed the background color of the fab button

## What is the new behavior?
It's now a deeper pink 
<!-- Please describe the new behavior after your modifications. -->
![image](https://github.com/unoplatform/uno.chefs/assets/90481654/b5f06495-64d7-4da8-b812-6e77e4789775)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

Not sure if we should make move the lightweight styling elsewhere

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
