### PR TITLE
fix: avoid crash when resizing screen on MyCookbook page

### DIFF
--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -103,7 +103,7 @@
 											   Source="{Binding CookbookImages.FirstImage}"
 											   Stretch="UniformToFill" />
 									</Border>
-									
+
 									<Grid RowSpacing="4"
 										  utu:AutoLayout.CounterAlignment="Stretch"
 										  utu:AutoLayout.PrimaryAlignment="Stretch">
@@ -121,7 +121,7 @@
 												   Stretch="UniformToFill"
 												   Visibility="{Binding CookbookImages.SecondImage, Converter={StaticResource NullToCollapsed}}" />
 										</Border>
-										
+
 										<Grid Grid.Row="1"
 											  utu:AutoLayout.CounterAlignment="Stretch"
 											  utu:AutoLayout.PrimaryAlignment="Stretch"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#208 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

App crash when resizing widows

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
resize screen with no crash


https://github.com/unoplatform/uno.chefs/assets/34275909/3ea5ff67-8a2f-4f2f-9fb1-5382cb5e7c80



## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
