### PR TITLE
fix: remove margin for image, apply it to text

### DIFF
--- a/src/Chefs/Views/WelcomePage.xaml
+++ b/src/Chefs/Views/WelcomePage.xaml
@@ -63,7 +63,6 @@
 					<FlipView x:Name="flipView"
 							  utu:AutoLayout.PrimaryAlignment="Stretch"
 							  Background="Transparent"
-							  Margin="32,0"
 							  SelectedIndex="{Binding NextPage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
 						<FlipView.Items>
 							<!-- First onboarding page -->
@@ -82,9 +81,11 @@
 										   Style="{StaticResource TitleLarge}"
 										   Text="Welcome to Your App!"
 										   TextAlignment="Center"
+										   Margin="32,0"
 										   TextWrapping="Wrap" />
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleMedium}"
+										   Margin="32,0"
 										   Text="Embark on a delightful coding journey as you discover, create, and share awesome script tailored to your app and project preferences."
 										   TextAlignment="Center"
 										   TextWrapping="Wrap" />
@@ -104,10 +105,12 @@
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleLarge}"
 										   Text="Explore Thousands of Recipes"
+										   Margin="32,0"
 										   TextAlignment="Center"
 										   TextWrapping="Wrap" />
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleMedium}"
+										   Margin="32,0"
 										   Text="Find your next culinary adventure or last minute lunch from our vast collection of diverse and mouth-watering recipes."
 										   TextAlignment="Center"
 										   TextWrapping="Wrap" />
@@ -126,11 +129,13 @@
 									   Source="{ThemeResource ChefsLogoWithIcon}" />
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleLarge}"
+										   Margin="32,0"
 										   Text="Personalize Your Recipe Journey"
 										   TextAlignment="Center"
 										   TextWrapping="Wrap" />
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleMedium}"
+										   Margin="32,0"
 										   Text="Create your own recipe collections, cookbooks, follow other foodies, and share your creations with the Chefs community."
 										   TextAlignment="Center"
 										   TextWrapping="Wrap" />


### PR DESCRIPTION
GitHub Issue (If applicable): #

unoplatform/uno.chefs-archived#198 

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Margin was apply to images


## What is the new behavior?

remove margin for image, apply it to text

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

![image](https://github.com/unoplatform/uno.chefs/assets/84541881/7cac78f9-7142-44f3-a234-14ef65cff30c)

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
