### PR TITLE
fix: save cookbook padding

### DIFF
--- a/src/Chefs/Views/CreateUpdateCookbookPage.xaml
+++ b/src/Chefs/Views/CreateUpdateCookbookPage.xaml
@@ -173,7 +173,7 @@
 					CornerRadius="4"
 					Style="{StaticResource TextButtonStyle}" />
 			<Button Height="59"
-					Padding="24,20"
+					Padding="4,20"
 					utu:AutoLayout.CounterAlignment="Start"
 					utu:AutoLayout.PrimaryAlignment="Stretch"
 					Command="{Binding Submit}"


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#193 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR


- Feature- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->
- Bugfix
## What is the current behavior?
There is too much horizontal padding in the save/create cookbook button, 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
![image](https://github.com/unoplatform/uno.chefs/assets/90481654/14387bb0-27c9-4de1-8075-6d81eae3db90)

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
