### PR TITLE
chore: moved recipedetails messenger calls to service

### DIFF
--- a/src/Chefs/Presentation/RecipeDetailsModel.cs
+++ b/src/Chefs/Presentation/RecipeDetailsModel.cs
@@ -28,14 +28,12 @@ public partial class RecipeDetailsModel
 
 	public async ValueTask Like(Review review, CancellationToken ct)
 	{
-		var reviewUpdated = await _recipeService.LikeReview(review, ct);
-		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, reviewUpdated));
+		await _recipeService.LikeReview(review, ct);
 	}
 
 	public async ValueTask Dislike(Review review, CancellationToken ct)
 	{
-		var reviewUpdated = await _recipeService.DislikeReview(review, ct);
-		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, reviewUpdated));
+		await _recipeService.DislikeReview(review, ct);
 	}
 
 	public async ValueTask LiveCooking(IImmutableList<Step> steps, CancellationToken ct)

--- a/src/Chefs/Presentation/ReviewsModel.cs
+++ b/src/Chefs/Presentation/ReviewsModel.cs
@@ -33,14 +33,12 @@ public partial class ReviewsModel
 
 	public async ValueTask Like(Review review, CancellationToken ct)
 	{
-		var reviewUpdated = await _recipeService.LikeReview(review, ct);
-		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, reviewUpdated));
+		await _recipeService.LikeReview(review, ct);
 	}
 
 	public async ValueTask Dislike(Review review, CancellationToken ct)
 	{
-		var reviewUpdated = await _recipeService.DislikeReview(review, ct);
-		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, reviewUpdated));
+		await _recipeService.DislikeReview(review, ct);
 	}
 
 	public ICommand AddReview => Command.Create(b => b.Given(Comment).When(CanComment).Then(Review));

--- a/src/Chefs/Services/Recipes/IRecipeService.cs
+++ b/src/Chefs/Services/Recipes/IRecipeService.cs
@@ -20,9 +20,8 @@ public interface IRecipeService
 	/// <param name="review">review to update</param>
 	/// <param name="ct"></param>
 	/// <returns>
-	/// New immutable list with dislikes update
 	/// </returns>
-	ValueTask<Review> DislikeReview(Review review, CancellationToken ct);
+	ValueTask DislikeReview(Review review, CancellationToken ct);
 
 	/// <summary>
 	/// Add current user like recipe review
@@ -30,9 +29,8 @@ public interface IRecipeService
 	/// <param name="review">review to update</param>
 	/// <param name="ct"></param>
 	/// <returns>
-	/// New immutable list with likes update
 	/// </returns>
-	ValueTask<Review> LikeReview(Review review, CancellationToken ct);
+	ValueTask LikeReview(Review review, CancellationToken ct);
 
 	/// <summary>
 	/// Recipes method

--- a/src/Chefs/Services/Recipes/RecipeService.cs
+++ b/src/Chefs/Services/Recipes/RecipeService.cs
@@ -107,11 +107,17 @@ public class RecipeService : IRecipeService
 		_messenger.Send(new EntityMessage<Recipe>(recipe.Save ? EntityChange.Created : EntityChange.Deleted, recipe));
 	}
 
-	public async ValueTask<Review> LikeReview(Review review, CancellationToken ct)
-		=> new(await _recipeEndpoint.LikeReview(review.ToData(), ct));
+	public async ValueTask LikeReview(Review review, CancellationToken ct)
+	{
+		var updatedReview = new Review(await _recipeEndpoint.LikeReview(review.ToData(), ct));
+		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, updatedReview));
+	}
 
-	public async ValueTask<Review> DislikeReview(Review review, CancellationToken ct)
-		=> new(await _recipeEndpoint.DislikeReview(review.ToData(), ct));
+	public async ValueTask DislikeReview(Review review, CancellationToken ct)
+	{
+		var updatedReview = new Review(await _recipeEndpoint.DislikeReview(review.ToData(), ct));
+		_messenger.Send(new EntityMessage<Review>(EntityChange.Updated, updatedReview));
+	}
 
 	public async ValueTask<IImmutableList<Recipe>> GetRecommended(CancellationToken ct)
 		=> (await _recipeEndpoint.GetAll(ct))


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#142 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

## What is the new behavior?
Moving IMessenger calls from Model to Service instead

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
