### PR TITLE
fix: cookbook editing binding

### DIFF
--- a/src/Chefs/Views/CookbookDetailPage.xaml
+++ b/src/Chefs/Views/CookbookDetailPage.xaml
@@ -121,7 +121,7 @@
 						<Button x:Name="FabButton"
 								HorizontalAlignment="Right"
 								VerticalAlignment="Bottom"
-								uen:Navigation.Data="{Binding Cookbook.Value, Mode=TwoWay}"
+								uen:Navigation.Data="{Binding Data, Mode=TwoWay}"
 								uen:Navigation.Request="UpdateCookbook"
 								utu:AutoLayout.IsIndependentLayout="True"
 								CornerRadius="56"


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#166 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Cookbook is null when trying to edit it.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

Binding works and cookbook is no longer null when editing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
