### PR TITLE
chore: fix autolayout alignments

### DIFF
--- a/src/Chefs/Views/SearchPage.xaml
+++ b/src/Chefs/Views/SearchPage.xaml
@@ -89,7 +89,7 @@
 									   Stretch="UniformToFill" />
 							</Border>
 							<utu:AutoLayout PrimaryAxisAlignment="Center"
-											Spacing="4"
+											CounterAxisAlignment="Start"
 											Padding="16">
 								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
 										   Style="{StaticResource TitleSmall}"


### PR DESCRIPTION
closes unoplatform/uno.chefs-archived#85 

Fixes a crash for AutoLayout that was reporting negative dimensions