### PR TITLE
ci: update artifact github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,12 @@ jobs:
           cd src/Chefs
           dotnet build -c Release /p:TargetFramework=net8.0-browserwasm "/p:PackageVersion=${{ steps.gitversion.outputs.fullSemVer }}" /bl:./artifacts-logs/build.binlog
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: wasm-site
           path: ${{ env.DIST_PATH }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: logs
           path: artifacts-logs


### PR DESCRIPTION
Avoiding GitHub Actions failure due to:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more:
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/