### PR TITLE
chore: refactor RecipeTemplates

### DIFF
--- a/src/Chefs/Views/CookbookDetailPage.xaml
+++ b/src/Chefs/Views/CookbookDetailPage.xaml
@@ -30,40 +30,6 @@
 								MinColumnSpacing="15"
 								MinItemWidth="240"
 								MinRowSpacing="15" />
-
-		<DataTemplate x:Key="RecipeTemplate">
-			<utu:CardContentControl x:Name="RecipeTemplateCard"
-									Background="{ThemeResource SurfaceBrush}"
-									CornerRadius="4"
-									Style="{StaticResource FilledCardContentControlStyle}">
-				<utu:CardContentControl.ContentTemplate>
-					<DataTemplate>
-						<utu:AutoLayout CornerRadius="4">
-							<Border x:Name="ImageLayout"
-									Height="144">
-								<Image HorizontalAlignment="Center"
-									   VerticalAlignment="Center"
-									   Source="{Binding ImageUrl}"
-									   Stretch="UniformToFill" />
-							</Border>
-							<utu:AutoLayout Padding="16"
-											PrimaryAxisAlignment="Center"
-											Spacing="4">
-
-								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-										   Style="{StaticResource TitleSmall}"
-										   Text="{Binding Name}"
-										   TextWrapping="Wrap" />
-								<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-										   Style="{StaticResource CaptionMedium}"
-										   Text="{Binding TimeCal}"
-										   TextWrapping="Wrap" />
-							</utu:AutoLayout>
-						</utu:AutoLayout>
-					</DataTemplate>
-				</utu:CardContentControl.ContentTemplate>
-			</utu:CardContentControl>
-		</DataTemplate>
 	</Page.Resources>
 
 	<utu:AutoLayout>

--- a/src/Chefs/Views/CreateUpdateCookbookPage.xaml
+++ b/src/Chefs/Views/CreateUpdateCookbookPage.xaml
@@ -31,7 +31,7 @@
 								MinItemWidth="240"
 								MinRowSpacing="15" />
 
-		<DataTemplate x:Key="RecipeTemplate"
+		<DataTemplate x:Key="CookbookRecipeTemplate"
 					  x:DataType="models:Recipe">
 			<ListViewItem x:Name="RecipeTemplateCard"
 						  Background="{ThemeResource SurfaceBrush}"
@@ -118,7 +118,7 @@
 								  utu:AutoLayout.PrimaryAlignment="Stretch"
 								  Source="{Binding Recipes}">
 						<DataTemplate>
-							<muxc:ItemsRepeater ItemTemplate="{StaticResource RecipeTemplate}"
+							<muxc:ItemsRepeater ItemTemplate="{StaticResource CookbookRecipeTemplate}"
 												ItemsSource="{Binding Data}"
 												utu:ItemsRepeaterExtensions.SelectionMode="Multiple"
 												utu:ItemsRepeaterExtensions.SupportsIncrementalLoading="True"

--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -179,40 +179,6 @@
 				</Button>
 			</utu:AutoLayout>
 		</DataTemplate>
-
-		<DataTemplate x:Key="RecipeTemplate">
-			<utu:CardContentControl Background="{ThemeResource SurfaceBrush}"
-									CornerRadius="4"
-									Style="{StaticResource FilledCardContentControlStyle}">
-				<utu:CardContentControl.ContentTemplate>
-					<DataTemplate>
-						<utu:AutoLayout CornerRadius="4">
-							<Border x:Name="ImageLayout"
-									Height="144">
-								<Image HorizontalAlignment="Center"
-									   VerticalAlignment="Center"
-									   Source="{Binding ImageUrl}"
-									   Stretch="UniformToFill" />
-							</Border>
-
-							<utu:AutoLayout Padding="16"
-											PrimaryAxisAlignment="Center"
-											CounterAxisAlignment="Start"
-											Spacing="4">
-								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-										   Style="{StaticResource TitleSmall}"
-										   Text="{Binding Name}"
-										   TextWrapping="Wrap" />
-								<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-										   Style="{StaticResource CaptionMedium}"
-										   Text="{Binding TimeCal}"
-										   TextWrapping="Wrap" />
-							</utu:AutoLayout>
-						</utu:AutoLayout>
-					</DataTemplate>
-				</utu:CardContentControl.ContentTemplate>
-			</utu:CardContentControl>
-		</DataTemplate>
 	</Page.Resources>
 
 	<utu:AutoLayout PrimaryAxisAlignment="Stretch">

--- a/src/Chefs/Views/ProfilePage.xaml
+++ b/src/Chefs/Views/ProfilePage.xaml
@@ -168,6 +168,7 @@
 							  HorizontalScrollMode="Disabled"
 							  VerticalScrollBarVisibility="Hidden">
 					<muxc:ItemsRepeater ItemsSource="{Binding Data}"
+										ItemTemplate="{StaticResource RecipeTemplate}"
 										uen:Navigation.Request="RecipeDetails"
 										Margin="16,0,16,16">
 						<muxc:ItemsRepeater.Layout>
@@ -177,47 +178,6 @@
 													MinRowSpacing="8"
 													ItemsStretch="Fill" />
 						</muxc:ItemsRepeater.Layout>
-						<muxc:ItemsRepeater.ItemTemplate>
-							<!--
-								Using an x:bind for windows as a workaround for now regarding this WinUI issue:
-								https://github.com/microsoft/microsoft-ui-xaml/issues/6689
-							-->
-							<DataTemplate x:DataType="models:Recipe">
-								<Border win:DataContext="{x:Bind}">
-									<utu:CardContentControl x:Name="RecipeTemplateCard"
-															Background="{ThemeResource SurfaceBrush}"
-															CornerRadius="4"
-															Style="{StaticResource FilledCardContentControlStyle}">
-										<utu:CardContentControl.ContentTemplate>
-											<DataTemplate>
-												<utu:AutoLayout CornerRadius="4">
-													<Border x:Name="ImageLayout"
-															Height="144">
-														<Image HorizontalAlignment="Center"
-															   VerticalAlignment="Center"
-															   Source="{Binding ImageUrl}"
-															   Stretch="UniformToFill" />
-													</Border>
-
-													<utu:AutoLayout Padding="16"
-																	PrimaryAxisAlignment="Center"
-																	Spacing="4">
-														<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-																   Style="{StaticResource TitleSmall}"
-																   Text="{Binding Name}"
-																   TextWrapping="Wrap" />
-														<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-																   Style="{StaticResource CaptionMedium}"
-																   Text="{Binding TimeCal}"
-																   TextWrapping="Wrap" />
-													</utu:AutoLayout>
-												</utu:AutoLayout>
-											</DataTemplate>
-										</utu:CardContentControl.ContentTemplate>
-									</utu:CardContentControl>
-								</Border>
-							</DataTemplate>
-						</muxc:ItemsRepeater.ItemTemplate>
 					</muxc:ItemsRepeater>
 				</ScrollViewer>
 			</DataTemplate>

--- a/src/Chefs/Views/SearchPage.xaml
+++ b/src/Chefs/Views/SearchPage.xaml
@@ -69,42 +69,6 @@
 			</utu:AutoLayout>
 		</DataTemplate>
 
-		<DataTemplate x:Key="RecipeTemplate">
-			<utu:CardContentControl x:Name="RecipeTemplateCard"
-									HorizontalAlignment="Stretch"
-									VerticalAlignment="Stretch"
-									Background="{ThemeResource SurfaceBrush}"
-									Style="{StaticResource FilledCardContentControlStyle}">
-				<utu:CardContentControl.ContentTemplate>
-					<DataTemplate>
-						<utu:AutoLayout HorizontalAlignment="Stretch"
-										Background="{ThemeResource SurfaceBrush}"
-										CornerRadius="4"
-										PrimaryAxisAlignment="Center">
-							<Border Height="144">
-								<Image HorizontalAlignment="Center"
-									   VerticalAlignment="Center"
-									   Source="{Binding ImageUrl}"
-									   Stretch="UniformToFill" />
-							</Border>
-							<utu:AutoLayout PrimaryAxisAlignment="Center"
-											CounterAxisAlignment="Start"
-											Padding="16">
-								<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
-										   Style="{StaticResource TitleSmall}"
-										   Text="{Binding Name}"
-										   TextWrapping="Wrap" />
-								<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
-										   Style="{StaticResource CaptionMedium}"
-										   Text="{Binding TimeCal}"
-										   TextWrapping="Wrap" />
-							</utu:AutoLayout>
-						</utu:AutoLayout>
-					</DataTemplate>
-				</utu:CardContentControl.ContentTemplate>
-			</utu:CardContentControl>
-		</DataTemplate>
-
 		<muxc:UniformGridLayout x:Key="NarrowGridLayout"
 								ItemsStretch="Fill"
 								MaximumRowsOrColumns="2"

--- a/src/Chefs/Views/Templates/ItemTemplates.xaml
+++ b/src/Chefs/Views/Templates/ItemTemplates.xaml
@@ -2,6 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 					xmlns:utu="using:Uno.Toolkit.UI"
 					xmlns:uer="using:Uno.Extensions.Reactive.UI">
+
 	<DataTemplate x:Key="ReviewDataTemplate">
 		<utu:AutoLayout Background="{ThemeResource SurfaceBrush}"
 						CornerRadius="15"
@@ -54,5 +55,41 @@
 				</utu:AutoLayout>
 			</utu:AutoLayout>
 		</utu:AutoLayout>
+	</DataTemplate>
+
+	<DataTemplate x:Key="RecipeTemplate">
+		<utu:CardContentControl x:Name="RecipeTemplateCard"
+								HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								Background="{ThemeResource SurfaceBrush}"
+								Style="{StaticResource FilledCardContentControlStyle}">
+			<utu:CardContentControl.ContentTemplate>
+				<DataTemplate>
+					<utu:AutoLayout HorizontalAlignment="Stretch"
+									Background="{ThemeResource SurfaceBrush}"
+									CornerRadius="4"
+									PrimaryAxisAlignment="Center">
+						<Border Height="144">
+							<Image HorizontalAlignment="Center"
+								   VerticalAlignment="Center"
+								   Source="{Binding ImageUrl}"
+								   Stretch="UniformToFill" />
+						</Border>
+						<utu:AutoLayout PrimaryAxisAlignment="Center"
+										CounterAxisAlignment="Start"
+										Padding="16">
+							<TextBlock Foreground="{ThemeResource OnSurfaceBrush}"
+									   Style="{StaticResource TitleSmall}"
+									   Text="{Binding Name}"
+									   TextWrapping="Wrap" />
+							<TextBlock Foreground="{ThemeResource OnSurfaceMediumBrush}"
+									   Style="{StaticResource CaptionMedium}"
+									   Text="{Binding TimeCal}"
+									   TextWrapping="Wrap" />
+						</utu:AutoLayout>
+					</utu:AutoLayout>
+				</DataTemplate>
+			</utu:CardContentControl.ContentTemplate>
+		</utu:CardContentControl>
 	</DataTemplate>
 </ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#81 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

Extracts the RecipeTemplate into the generic Templates.xaml file. We can now use it everywhere in the app.

Some pages had very slight variations of the same template (like a missing AutoLayout Stretch for example). I came up with the most logical template for all pages.

For the CookbookDetailsPage we also use the RecipeTemplate but with an added "toggle button" for the selection states of the cookbooks. I wasn't able to find a simple way to include that in the same template as the others, so I left it as is.