### PR TITLE
fix: Cookbook Details Navigation

### DIFF
--- a/src/Chefs/Presentation/CookbookDetailModel.cs
+++ b/src/Chefs/Presentation/CookbookDetailModel.cs
@@ -4,12 +4,15 @@ namespace Chefs.Presentation;
 public partial record CookbookDetailModel
 {
 	private readonly IMessenger _messenger;
+
+	private readonly Cookbook _cookbook;
 	public CookbookDetailModel(Cookbook cookbook, IMessenger messenger)
 	{
-		_messenger = messenger; 
+		_messenger = messenger;
+		_cookbook = cookbook ?? new Cookbook();
 	}
 	
 	public IState<Cookbook> Cookbook => State
-		.Value(this, () => new Cookbook())
+		.Value(this, () => _cookbook ?? new Cookbook())
 		.Observe(_messenger, cb => cb.Id);
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#76

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

Tapping on a cookbook list item navigates to an empty page


## What is the new behavior?

Tapping on a cookbook list item navigates to the cookbook details page


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
