### PR TITLE
chore: add workaround for vulnerable transitive dependency

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,6 @@
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' OR $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'macos'">
 		<!-- Workaround: For iOS/macOS builds, System.Private.Uri is pulled implicitly with a vulnerable version -->
 		<!-- There is a bit of related discussions in https://github.com/dotnet/sdk/issues/30659 -->
-		<PackageReference Include="System.Private.Uri" Version="4.3.2" />
+		<PackageReference Include="System.Private.Uri" />
 	</ItemGroup>
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -14,5 +14,6 @@
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.4.2" />
     <PackageVersion Include="Xamarin.UITest" Version="4.1.2" />
-  </ItemGroup>
+		<PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Use workaround from here: https://github.com/unoplatform/uno/blob/9923d6d2693aa9c63b15ad1c584ba4fbc83f4e30/src/Directory.Build.targets#L156