### PR TITLE
chore: bump sdk

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,9 +16,4 @@
 		<PackageVersion Include="Xamarin.UITest" Version="4.1.2" />
 		<PackageVersion Include="System.Private.Uri" Version="4.3.2" />
 	</ItemGroup>
-
-	<PropertyGroup>
-		<!-- TOOD: Remove once new Uno.Sdk is released with the Toolkit changes s-->
-		<UnoToolkitVersion>6.4.0-dev.51</UnoToolkitVersion>
-	</PropertyGroup>
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
 	// To update the version of Uno please update the version of the Uno.Sdk here. See https://aka.platform.uno/upgrade-uno-packages for more information.
 	"msbuild-sdks": {
-		"Uno.Sdk": "5.6.0-dev.140"
+		"Uno.Sdk": "5.6.0-dev.148"
 	}
 }


### PR DESCRIPTION
bump sdk to latest 5.6.0-dev that includes the latest Toolkit dev packages needed for fixes