### PR TITLE
fix: Remove unnecessary style from PathIcon

### DIFF
--- a/src/Chefs/Views/FavoriteRecipesPage.xaml
+++ b/src/Chefs/Views/FavoriteRecipesPage.xaml
@@ -56,7 +56,6 @@
 						Style="{StaticResource TextButtonStyle}">
 					<ut:ControlExtensions.Icon>
 						<PathIcon Data="{StaticResource Icon_Add}"
-								  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
 								  Foreground="{ThemeResource PrimaryBrush}" />
 					</ut:ControlExtensions.Icon>
 				</Button>
@@ -121,7 +120,6 @@
 												Visibility="{Binding CookbookImages.ThirdImage, Converter={StaticResource NullToVisible}}">
 											<Button.Content>
 												<PathIcon Data="{StaticResource Icon_Add}"
-														  Style="{StaticResource FontAwesomeSolidFontIconStyle}"
 														  Foreground="{ThemeResource OnSurfaceBrush}" />
 											</Button.Content>
 										</Button>


### PR DESCRIPTION
GitHub Issue (If applicable): unoplatform/uno.chefs-archived#49

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
Cookbook tab crashes on windows due to unnecessary style set to `PathIcon`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
No crash
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
