### PR TITLE
fix: Clear Search filters when opening tab

### DIFF
--- a/src/Chefs/Views/MainPage.xaml
+++ b/src/Chefs/Views/MainPage.xaml
@@ -45,7 +45,7 @@
 				</utu:TabBarItem.Icon>
 			</utu:TabBarItem>
 
-			<utu:TabBarItem uen:Region.Name="Search"
+			<utu:TabBarItem uen:Region.Name="-/Search"
 							Content="Search">
 				<utu:TabBarItem.Icon>
 					<PathIcon Data="{StaticResource Icon_Search}" />
@@ -76,7 +76,7 @@
 					</utu:TabBarItem.Icon>
 				</utu:TabBarItem>
 
-				<utu:TabBarItem uen:Region.Name="Search"
+				<utu:TabBarItem uen:Region.Name="-/Search"
 								Content="Search">
 					<utu:TabBarItem.Icon>
 						<PathIcon Data="{StaticResource Icon_Search}" />


### PR DESCRIPTION
GitHub Issue (If applicable): #1339

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix
<!-- Please uncomment one ore more that apply to this PR


- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?
When a user clicks on 'View All' from any segment on the home screen, or anywhere that would apply a filter to the SearchPage, the selection is carried over to the search page (via the main tab). Upon navigating to the search page, the user must first clear the pre-applied filter before being able to search for any recipe.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
When opening the Search page the filters are reset.
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

