### PR TITLE
fix: workaround for ios responsive flyout

### DIFF
--- a/src/Chefs/Views/Flyouts/ResponsiveDrawerFlyout.xaml.cs
+++ b/src/Chefs/Views/Flyouts/ResponsiveDrawerFlyout.xaml.cs
@@ -34,6 +34,12 @@ public partial class ResponsiveDrawerFlyout : Flyout, IRecipient<ThemeChangedMes
 				DrawerFlyoutPresenter.SetDrawerLength(presenter, new GridLength(1, GridUnitType.Star));
 				DrawerFlyoutPresenter.SetIsGestureEnabled(presenter, false);
 			}
+
+			// Workaround for https://github.com/unoplatform/uno.chefs/issues/1436
+			// Not explicitly setting thickness causes thickness to be set to a value greater than 1 sometime during runtime
+#if __IOS__
+			presenter.BorderThickness = new Thickness(0);
+#endif
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#36 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

No more white border:

![image](https://github.com/user-attachments/assets/ad276faf-a0e2-4c6b-834c-00f040caedf5)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
