### PR TITLE
fix: BooleanConverter Error when Liking/Disliking a recipe

### DIFF
--- a/src/Chefs/Converters/FromBoolToValueConverter.cs
+++ b/src/Chefs/Converters/FromBoolToValueConverter.cs
@@ -39,10 +39,6 @@ public class FromBoolToValueConverter : IValueConverter
 		}
 	}
 
-	//Issue 642:[Windows] Binding not properly setting value to ToggleButton
-	//https://github.com/unoplatform/uno.chefs/issues/642
-	//We needed to use two-way binding to prevent the {Binding} from being cleared when modified by the control (ex: ToggleButton's IsChecked when pressed) and with that, it should no longer throw not-suppported for ConvertBack.
-
 	public object ConvertBack(object value, Type targetType, object parameter, string language)
 	{
 		return value;


### PR DESCRIPTION
GitHub Issue (If applicable): closes unoplatform/uno.chefs-archived#28 
## PR Type

What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

![image](https://github.com/user-attachments/assets/a8371ac6-353b-4fab-9d2d-b5d2c8edffb8)


## What is the new behavior?

No converter errors.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
