### PR TITLE
chore: add json gen context for appconfig settings

### DIFF
--- a/Chefs/App.xaml.cs
+++ b/Chefs/App.xaml.cs
@@ -90,8 +90,9 @@ public partial class App : Application
 				// Enable localization (see appsettings.json for supported languages)
 				.UseLocalization()
 
-				// Register Json serializers (ISerializer and ISerializer)
+				// Register Json serializers (ISerializer)
 				.UseSerialization((context, services) => services
+#if USE_MOCKS
 					.AddJsonTypeInfo(MockEndpointContext.Default.ListCookbookData)
 					.AddJsonTypeInfo(MockEndpointContext.Default.ListSavedCookbooksData)
 					.AddJsonTypeInfo(MockEndpointContext.Default.CookbookData)
@@ -112,6 +113,8 @@ public partial class App : Application
 					.AddJsonTypeInfo(MockEndpointContext.Default.SavedRecipesData)
 					.AddJsonTypeInfo(MockEndpointContext.Default.IEnumerableRecipeData)
 					.AddJsonTypeInfo(MockEndpointContext.Default.IEnumerableSavedRecipesData)
+#endif
+					.AddJsonTypeInfo(AppConfigContext.Default.AppConfig)
 					.AddContentSerializer(context))
 
 				.ConfigureServices((context, services) =>

--- a/Chefs/Business/Models/AppConfig.cs
+++ b/Chefs/Business/Models/AppConfig.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Chefs.Business.Models;
 
 public record AppConfig
@@ -6,4 +8,9 @@ public record AppConfig
 	public bool? IsDark { get; init; }
 	public bool? Notification { get; init; }
 	public string? AccentColor { get; init; }
+}
+
+[JsonSerializable(typeof(AppConfig))]
+public partial class AppConfigContext : JsonSerializerContext
+{
 }


### PR DESCRIPTION
Fix for crash on WASM in release when trying to deserialize AppConfig