### PR TITLE
chore: remove unneccessary back/close icon MainCommand definitions

### DIFF
--- a/Chefs/Styles/NavigationBar.xaml
+++ b/Chefs/Styles/NavigationBar.xaml
@@ -25,11 +25,30 @@
 		   BasedOn="{StaticResource MaterialAppBarButtonStyle}" />
 
 	<Style x:Key="ChefsMainCommandStyle"
-		   BasedOn="{StaticResource ChefsAppBarButtonStyle}"
+		   BasedOn="{StaticResource MaterialMainCommandStyle}"
 		   TargetType="AppBarButton">
 		<!-- Set the MainCommand content to an empty string to remove the default "Back" text on iOS -->
 		<mobile:Setter Property="Content"
 					   Value="" />
+	</Style>
+
+	<Style x:Key="ChefsModalNavigationBarStyle"
+		   BasedOn="{StaticResource ChefsNavigationBarStyle}"
+		   TargetType="utu:NavigationBar">
+		<Setter Property="utu:ResourceExtensions.Resources">
+			<Setter.Value>
+				<ResourceDictionary>
+					<ResourceDictionary.ThemeDictionaries>
+						<ResourceDictionary x:Key="Light">
+							<StaticResource x:Key="NavigationBarBackIconData" ResourceKey="Icon_Close" />
+						</ResourceDictionary>
+						<ResourceDictionary x:Key="Dark">
+							<StaticResource x:Key="NavigationBarBackIconData" ResourceKey="Icon_Close" />
+						</ResourceDictionary>
+					</ResourceDictionary.ThemeDictionaries>
+				</ResourceDictionary>
+			</Setter.Value>
+		</Setter>
 	</Style>
 
 	<Style TargetType="utu:NavigationBar"

--- a/Chefs/Views/CookbookDetailPage.xaml
+++ b/Chefs/Views/CookbookDetailPage.xaml
@@ -32,15 +32,7 @@
 
 	<utu:AutoLayout>
 		<utu:NavigationBar Content="{Binding Cookbook.Name}"
-						   utu:AutoLayout.PrimaryAlignment="Auto">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
-		</utu:NavigationBar>
+						   utu:AutoLayout.PrimaryAlignment="Auto" />
 		<uer:FeedView utu:AutoLayout.PrimaryAlignment="Stretch"
 					  Source="{Binding Cookbook}">
 			<DataTemplate>

--- a/Chefs/Views/CreateUpdateCookbookPage.xaml
+++ b/Chefs/Views/CreateUpdateCookbookPage.xaml
@@ -90,15 +90,7 @@
 
 	<utu:AutoLayout>
 		<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch">
-			<utu:NavigationBar Content="{Binding Title}">
-				<utu:NavigationBar.MainCommand>
-					<AppBarButton>
-						<AppBarButton.Icon>
-							<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-						</AppBarButton.Icon>
-					</AppBarButton>
-				</utu:NavigationBar.MainCommand>
-			</utu:NavigationBar>
+			<utu:NavigationBar Content="{Binding Title}" />
 
 			<!-- It is necessary to disable the HorizontalScrollMode because of this issue: https://github.com/unoplatform/uno/issues/12871 -->
 			<ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"

--- a/Chefs/Views/FiltersPage.xaml
+++ b/Chefs/Views/FiltersPage.xaml
@@ -28,16 +28,8 @@
 		<utu:AutoLayout uen:Region.Attached="True"
 						utu:AutoLayout.PrimaryAlignment="Stretch"
 						PrimaryAxisAlignment="Stretch">
-			<utu:NavigationBar Content="Filters">
-				<utu:NavigationBar.MainCommand>
-					<AppBarButton uen:Navigation.Request="-">
-						<AppBarButton.Icon>
-							<not_mobile:PathIcon Data="{StaticResource Icon_Close}" />
-							<mobile:BitmapIcon UriSource="ms-appx:///Assets/Icons/close.png" />
-						</AppBarButton.Icon>
-					</AppBarButton>
-				</utu:NavigationBar.MainCommand>
-			</utu:NavigationBar>
+			<utu:NavigationBar Content="Filters"
+							   Style="{StaticResource ChefsModalNavigationBarStyle}" />
 			<ScrollViewer HorizontalScrollMode="Disabled"
 						  utu:AutoLayout.PrimaryAlignment="Stretch">
 				<utu:AutoLayout Padding="16"

--- a/Chefs/Views/LiveCookingPage.xaml
+++ b/Chefs/Views/LiveCookingPage.xaml
@@ -88,15 +88,7 @@
 		<utu:NavigationBar x:Name="NavBar"
 						   utu:AutoLayout.PrimaryAlignment="Auto"
 						   Style="{StaticResource ChefsNavigationBarStyle}"
-						   Content="{Binding Recipe.Name}">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
-		</utu:NavigationBar>
+						   Content="{Binding Recipe.Name}" />
 
 		<utu:AutoLayout utu:AutoLayout.PrimaryAlignment="Stretch"
 						Orientation="{utu:Responsive Narrow=Vertical,

--- a/Chefs/Views/MapPage.xaml
+++ b/Chefs/Views/MapPage.xaml
@@ -17,15 +17,7 @@
 	  utu:StatusBar.Background="{ThemeResource SurfaceInverseBrush}"
 	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<utu:AutoLayout>
-		<utu:NavigationBar Content="Near me">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
-		</utu:NavigationBar>
+		<utu:NavigationBar Content="Near me" />
 		<map:MapControl x:Name="MapControl"
 						utu:AutoLayout.PrimaryAlignment="Stretch" />
 	</utu:AutoLayout>

--- a/Chefs/Views/NotificationsPage.xaml
+++ b/Chefs/Views/NotificationsPage.xaml
@@ -78,16 +78,8 @@
 	</Page.Resources>
 	<utu:AutoLayout PrimaryAxisAlignment="Stretch">
 		<utu:NavigationBar Content="Notifications"
-						   utu:AutoLayout.PrimaryAlignment="Auto">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<not_mobile:PathIcon Data="{StaticResource Icon_Close}" />
-						<mobile:BitmapIcon UriSource="ms-appx:///Assets/Icons/close.png" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
-		</utu:NavigationBar>
+						   Style="{StaticResource ChefsModalNavigationBarStyle}"
+						   utu:AutoLayout.PrimaryAlignment="Auto" />
 		<utu:AutoLayout Background="{ThemeResource BackgroundBrush}"
 						uen:Region.Attached="True"
 						utu:AutoLayout.PrimaryAlignment="Stretch"

--- a/Chefs/Views/ProfilePage.xaml
+++ b/Chefs/Views/ProfilePage.xaml
@@ -58,15 +58,8 @@
 
 	<utu:AutoLayout>
 		<utu:NavigationBar Content="Profile"
+						   Style="{StaticResource ChefsModalNavigationBarStyle}"
 						   utu:AutoLayout.PrimaryAlignment="Auto">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<not_mobile:PathIcon Data="{StaticResource Icon_Close}" />
-						<mobile:BitmapIcon UriSource="ms-appx:///Assets/Icons/close.png" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
 			<utu:NavigationBar.PrimaryCommands>
 				<AppBarButton uen:Navigation.Request="Settings"
 							  uen:Navigation.Data="{Binding Profile.Value}"

--- a/Chefs/Views/RecipeDetailsPage.xaml
+++ b/Chefs/Views/RecipeDetailsPage.xaml
@@ -45,11 +45,6 @@
 
 	<utu:AutoLayout>
 		<utu:NavigationBar Content="{Binding Recipe.Name}">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
 			<utu:NavigationBar.PrimaryCommands>
 				<AppBarButton Command="{Binding Share}">
 					<AppBarButton.Icon>

--- a/Chefs/Views/SettingsPage.xaml
+++ b/Chefs/Views/SettingsPage.xaml
@@ -19,15 +19,7 @@
 
 	<utu:AutoLayout>
 		<utu:NavigationBar Content="Settings"
-						   utu:AutoLayout.PrimaryAlignment="Auto">
-			<utu:NavigationBar.MainCommand>
-				<AppBarButton>
-					<AppBarButton.Icon>
-						<PathIcon Data="{StaticResource Icon_Arrow_Back}" />
-					</AppBarButton.Icon>
-				</AppBarButton>
-			</utu:NavigationBar.MainCommand>
-		</utu:NavigationBar>
+						   utu:AutoLayout.PrimaryAlignment="Auto" />
 		<!-- Horizontal scrolling is disabled due to this bug: https://github.com/unoplatform/uno/issues/12871 -->
 		<ScrollViewer utu:AutoLayout.PrimaryAlignment="Stretch"
 					  HorizontalScrollMode="Disabled">


### PR DESCRIPTION
We do not need to explicitly define MainCommands with the default Back icon

And for customizing the icon to show something like an X in our modal pages, we can use lightweight styling to override the icon path data instead