### PR TITLE
fix: notifications states

### DIFF
--- a/Chefs/Services/Clients/Models/NotificationData.cs
+++ b/Chefs/Services/Clients/Models/NotificationData.cs
@@ -62,7 +62,7 @@ namespace Chefs.Services.Clients.Models
 				{ "title", n => { Title = n.GetStringValue(); } },
 				{ "description", n => { Description = n.GetStringValue(); } },
 				{ "date", n => { Date = n.GetDateTimeOffsetValue(); } },
-				{ "isRead", n => { IsRead = n.GetBoolValue(); } },
+				{ "read", n => { IsRead = n.GetBoolValue(); } },
 			};
 		}
 
@@ -77,7 +77,7 @@ namespace Chefs.Services.Clients.Models
 			writer.WriteStringValue("title", Title);
 			writer.WriteStringValue("description", Description);
 			writer.WriteDateTimeOffsetValue("date", Date);
-			writer.WriteBoolValue("isRead", IsRead);
+			writer.WriteBoolValue("read", IsRead);
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1563

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix

1) Notifications are now in their correct default state (JSON contains "read" whereas we were trying to get "isRead")
2) Add negative margin to icon to center it (tried getting a new svg from figma but was the same outcome)