### PR TITLE
fix: update bug-report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -38,7 +38,6 @@ If the matter is security related, please disclose it privately via https://gith
 ## Uno Version(s)
 
 - Uno.Sdk Version:
-- Uno Extension Version:
 
 ## Affected platform(s)
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -23,28 +23,34 @@ If the matter is security related, please disclose it privately via https://gith
 
 ## Environment
 
-<!-- For bug reports Check one or more of the following options with "x" -->
+<!-- For bug reports Check one or more of the following options with "x" and add the version you working with.-->
+- [ ] Visual Studio 2022 (version: )
+- [ ] Visual Studio 2022 for Mac (version: )
+- [ ] Visual Studio Code (version: )
+- [ ] Rider Windows
+- [ ] Rider macOS
+- [ ] Rider Linux
 
-Nuget Package:
+## Nuget Package(s)
 
-Package Version(s):
+<!-- Are there specific Nuget Packages causing this problem? Please add their depending version you used-->
 
-Affected platform(s):
+## Uno Version(s)
+
+- Uno.Sdk Version:
+- Uno Extension Version:
+
+## Affected platform(s)
 
 - [ ] iOS
 - [ ] Android
 - [ ] WebAssembly
 - [ ] WebAssembly renders for Xamarin.Forms
 - [ ] Windows
+- [ ] Desktop
 - [ ] Build tasks
 
-Visual Studio:
-
-- [ ] 2017 (version: )
-- [ ] 2019 (version: )
-- [ ] for Mac (version: )
-
-Relevant plugins:
+## Relevant plugins
 
 - [ ] Resharper (version: )
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bugfix at .github/templates
<!-- Please uncomment one ore more that apply to this PR

- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- current template gives options for Visual Studio 2017 and 2019 which is no where stated to be supported at all
- desktop target missing
- Rider IDE missing completly
- it asks for ticking at least one option while there is not one listed, bit difficult to check them  in this case ;)

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
updated to get at least near the uno.ui bug-report template from the questions and options, but yml format would be better!

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
