### PR TITLE
refactor(ConfigurationExtensions): Link configuration markdown file to actual source code

### DIFF
--- a/Chefs/App.xaml.host.cs
+++ b/Chefs/App.xaml.host.cs
@@ -38,7 +38,7 @@ public partial class App : Application
 				// Switch to Development environment when running in DEBUG
 				.UseEnvironment(Environments.Development)
 #endif
-				// Temporary until uno loggig is fixed in extensions.
+				// Temporary until uno logging is fixed in extensions.
 				//.UseLogging(configure: (context, logBuilder) =>
 				//{
 				//	// Configure log levels for different categories of logging
@@ -71,8 +71,8 @@ public partial class App : Application
 				})
 				.ConfigureAppConfiguration(config =>
 				{
-					// Clear any launchurl to make sure we always start at beginning
-					// Deeplinking issue https://github.com/unoplatform/uno.chefs/issues/738
+					// Clear any launch url to make sure we always start at beginning
+					// Deep linking issue https://github.com/unoplatform/uno.chefs/issues/738
 					var appsettingsPrefix = new Dictionary<string, string?>
 							{
 								{ HostingConstants.LaunchUrlKey, "" }

--- a/Chefs/Services/Users/UserService.cs
+++ b/Chefs/Services/Users/UserService.cs
@@ -10,7 +10,7 @@ public class UserService(
 	: IUserService
 {
 	private readonly IWritableOptions<Credentials> _credentialOptions = credentialOptions;
-	
+
 	private IState<User> _user => State.Async(this, GetCurrent);
 
 	public IFeed<User> User => _user;
@@ -48,8 +48,8 @@ public class UserService(
 	//In case we need to add auth
 	//public async ValueTask<bool> BasicAuthenticate(string email, string password, CancellationToken ct)
 	//{
-	//    var autentication = await _userEndpoint.Authenticate(email, password, ct);
-	//    if (autentication)
+	//    var authentication = await _userEndpoint.Authenticate(email, password, ct);
+	//    if (authentication)
 	//    {
 	//        await _credentialOptions.UpdateAsync(_ => new Credentials()
 	//        {

--- a/doc/extensions/ConfigurationExtensions.md
+++ b/doc/extensions/ConfigurationExtensions.md
@@ -14,65 +14,39 @@ Writable configuration from `Uno.Extensions.Configuration` provides you an inter
 
 ### Create a new record
 
-```csharp
-public record AppConfig
-{
-    public string? Title { get; init; }
-    public bool? IsDark { get; init; }
-    public bool? Notification { get; init; }
-    public string? AccentColor { get; init; }
-}
-```
+[!code-csharp[](../../Chefs/Business/Models/AppConfig.cs#L5-L11)]
 
 ### Add to your `IConfigBuilder`
 
 Use `Section<T>()` inside `UseConfiguration`. You can chain multiple configs.
 
-```csharp
-.UseConfiguration(configure: configBuilder =>
-    configBuilder
-        .EmbeddedSource<App>()
-        .Section<AppConfig>()
-        .Section<Credentials>()
-        .Section<SearchHistory>()
-)
-```
+[!code-csharp[](../../Chefs/App.xaml.host.cs#L48-L54)]
 
 ### Get and Update the value
 
 #### UserService.cs
 
-1. Inject `IWritableOptions<AppConfig>` in the constructor.
+1. Inject `IWritableOptions<AppConfig>` in the primary constructor of the UserService and store it in a `private readonly` property.
 
-    ```csharp
-    public class UserService(
-        ChefsApiClient client,
-        IWritableOptions<AppConfig> chefAppOptions,
-        IWritableOptions<Credentials> credentialOptions)
-        : IUserService
-    ```
+    [!code-csharp[](../../Chefs/Services/Users/UserService.cs#L7-L12)]
 
-2. Implement the logic to read and write to the configuration.
+#### SettingsService
+<!-- markdownlint-disable MD029 -->
+2. Implement the logic to read from to the configuration.
 
-    ```csharp
-    public async ValueTask<AppConfig> GetSettings(CancellationToken ct)
-        => chefAppOptions.Value;
-    ```
+    [!code-csharp[](../../Chefs/Services/Settings/SettingsService.cs#L5-L6)]
 
-    ```csharp
-    public async Task SetSettings(AppConfig chefSettings, CancellationToken ct)
-    {
-        var settings = new AppConfig
-        {
-        Title = chefSettings.Title,
-        IsDark = chefSettings.IsDark,
-        Notification = chefSettings.Notification,
-        AccentColor = chefSettings.AccentColor,
-        };
+3. To update them, which includes awaiting the current Settings from the ValueTask we just implemented
 
-        await chefAppOptions.UpdateAsync(_ => settings);
-    }
-    ```
+    [!code-csharp[](../../Chefs/Services/Settings/SettingsService.cs#L13-L23)]
+
+4. Implement the logic to write them back to the configuration.
+
+    [!code-csharp[](../../Chefs/Services/Settings/SettingsService.cs#L8-L11)]
+
+5. And then of course, connect the Update with the write-back.
+
+    [!code-csharp[](../../Chefs/Services/Settings/SettingsService.cs#L13-L27?highlight=25)]
 
 ## Source Code
 

--- a/doc/extensions/ConfigurationExtensions.md
+++ b/doc/extensions/ConfigurationExtensions.md
@@ -44,35 +44,35 @@ Use `Section<T>()` inside `UseConfiguration`. You can chain multiple configs.
 
 1. Inject `IWritableOptions<AppConfig>` in the constructor.
 
-```csharp
-public class UserService(
-    ChefsApiClient client,
-    IWritableOptions<AppConfig> chefAppOptions,
-    IWritableOptions<Credentials> credentialOptions)
-    : IUserService
-```
+    ```csharp
+    public class UserService(
+        ChefsApiClient client,
+        IWritableOptions<AppConfig> chefAppOptions,
+        IWritableOptions<Credentials> credentialOptions)
+        : IUserService
+    ```
 
 2. Implement the logic to read and write to the configuration.
 
-```csharp
-public async ValueTask<AppConfig> GetSettings(CancellationToken ct)
-    => chefAppOptions.Value;
-```
+    ```csharp
+    public async ValueTask<AppConfig> GetSettings(CancellationToken ct)
+        => chefAppOptions.Value;
+    ```
 
-```csharp
- public async Task SetSettings(AppConfig chefSettings, CancellationToken ct)
- {
-    var settings = new AppConfig
+    ```csharp
+    public async Task SetSettings(AppConfig chefSettings, CancellationToken ct)
     {
-    Title = chefSettings.Title,
-    IsDark = chefSettings.IsDark,
-    Notification = chefSettings.Notification,
-    AccentColor = chefSettings.AccentColor,
-    };
+        var settings = new AppConfig
+        {
+        Title = chefSettings.Title,
+        IsDark = chefSettings.IsDark,
+        Notification = chefSettings.Notification,
+        AccentColor = chefSettings.AccentColor,
+        };
 
-    await chefAppOptions.UpdateAsync(_ => settings);
- }
-```
+        await chefAppOptions.UpdateAsync(_ => settings);
+    }
+    ```
 
 ## Source Code
 


### PR DESCRIPTION
GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)
- Documentation content changes
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Build or CI related changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- hard coded sample which is indeed already not longer current and src is a bit different
- some cspell lintings

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
- applyed references of the code samples to use the actual src by using `[!code-csharp[](...)]`
- fixed cspell lintings I seen on the way of finding the lines to link by the mentioned markdown code tag

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features) [^1](#other-information)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
**The task point asking about the template should be updated, because uno.Chefs RecieptBook uses a different layout!**
But, yes, I did stay on current layout, just formatted and added the contents.

so we need here another template for adding docs 👍 

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
