### PR TITLE
chore: refactor recipe todata from cookbook service

### DIFF
--- a/Chefs/Business/Models/Cookbook.cs
+++ b/Chefs/Business/Models/Cookbook.cs
@@ -41,12 +41,23 @@ public partial record Cookbook : IChefEntity
 		Name = Name,
 		Recipes = recipes is null
 			? Recipes?
-				.Select(c => c.ToData())
+				.Select(r => r.ToData())
 				.ToList()
 			: recipes
-				.Select(c => c.ToData())
+				.Select(r => r.ToData())
 				.ToList()
 	};
+
+	internal static CookbookData CreateData(Guid userId, string name, IImmutableList<Recipe> recipes)
+	{
+		return new CookbookData
+		{
+			Id = Guid.NewGuid(),
+			Name = name,
+			UserId = userId,
+			Recipes = recipes?.Select(r => r.ToData()).ToList()
+		};
+	}
 
 	internal UpdateCookbook UpdateCookbook() => new(this);
 }

--- a/Chefs/Services/Cookbooks/CookbookService.cs
+++ b/Chefs/Services/Cookbooks/CookbookService.cs
@@ -10,13 +10,7 @@ public class CookbookService(ChefsApiClient client, IMessenger messenger, IUserS
 	public async ValueTask<Cookbook> Create(string name, IImmutableList<Recipe> recipes, CancellationToken ct)
 	{
 		var currentUser = await userService.GetCurrent(ct);
-		var cookbookData = new CookbookData
-		{
-			Id = Guid.NewGuid(),
-			Name = name,
-			UserId = currentUser.Id,
-			Recipes = recipes?.Select(i => i.ToData()).ToList()
-		};
+		var cookbookData = Cookbook.CreateData(currentUser.Id, name, recipes);
 
 		await client.Api.Cookbook.PostAsync(cookbookData, cancellationToken: ct);
 
@@ -25,9 +19,7 @@ public class CookbookService(ChefsApiClient client, IMessenger messenger, IUserS
 
 	public async ValueTask<Cookbook> Update(Cookbook cookbook, IImmutableList<Recipe> recipes, CancellationToken ct)
 	{
-		var updatedCookbookData = cookbook.ToData();
-		updatedCookbookData.Recipes = recipes.Select(r => r.ToData()).ToList();
-
+		var updatedCookbookData = cookbook.ToData(recipes);
 		await client.Api.Cookbook.PutAsync(updatedCookbookData, cancellationToken: ct);
 
 		var newCookbook = new Cookbook(updatedCookbookData);


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1581 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)

CookbookService no longer uses recipe.ToData() directly