### PR TITLE
fix: welcome flipview selection states

### DIFF
--- a/Chefs/Business/Models/Iterator.cs
+++ b/Chefs/Business/Models/Iterator.cs
@@ -33,14 +33,4 @@ public record IntIterator(IImmutableList<int> Items)
 	public int Count => Items.Count;
 	public bool CanMoveNext => CurrentIndex < Items.Count - 1;
 	public bool CanMovePrevious => CurrentIndex > 0;
-
-	public IntIterator MoveNext()
-		=> CanMoveNext
-			? this with { CurrentIndex = CurrentIndex + 1 }
-			: this;
-
-	public IntIterator MovePrevious()
-		=> CanMovePrevious
-			? this with { CurrentIndex = CurrentIndex - 1 }
-			: this;
 }

--- a/Chefs/Views/WelcomePage.xaml
+++ b/Chefs/Views/WelcomePage.xaml
@@ -46,6 +46,7 @@
 			<FlipView x:Name="flipView"
 					  utu:AutoLayout.PrimaryAlignment="Stretch"
 					  Background="Transparent"
+					  utu:SelectorExtensions.PipsPager="{Binding ElementName=pipsPager}"
 					  SelectedIndex="{Binding Pages.CurrentIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
 				<FlipView.Items>
 					<ctrl:WelcomeView ImageUrl="ms-appx:///Assets/Welcome/first_splash_screen.jpg"
@@ -66,13 +67,12 @@
 							PrimaryAxisAlignment="End"
 							Spacing="16">
 				<!-- Pips -->
-				<muxc:PipsPager x:Name="PipsPager"
+				<muxc:PipsPager x:Name="pipsPager"
 								Margin="0,0,0,10"
 								utu:AutoLayout.CounterAlignment="Center"
 								NumberOfPages="3"
 								MaxVisiblePips="3"
 								Orientation="Horizontal"
-								SelectedPageIndex="{Binding Pages.CurrentIndex, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
 								Style="{StaticResource PipsPagerStyle}" />
 
 				<!-- Buttons -->


### PR DESCRIPTION
GitHub Issue (If applicable): #1607

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

CanMoveNext/CanMovePrevious aren't reflected properly because both the PipsPager and the FlipView are changing the `CurrentIndex` at the same time.

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->

- Only the FlipView has TwoWay on the `CurrentIndex` (so that the Next/Previous buttons still set the index).
- Use of SelectorExtensions from Toolkit so that the PipsPager selection is taken into account by the FlipView.