### PR TITLE
chore: undo ios responsive flyout workaround

### DIFF
--- a/Chefs/Views/Flyouts/ResponsiveDrawerFlyout.xaml.cs
+++ b/Chefs/Views/Flyouts/ResponsiveDrawerFlyout.xaml.cs
@@ -34,12 +34,6 @@ public partial class ResponsiveDrawerFlyout : Flyout, IRecipient<ThemeChangedMes
 				DrawerFlyoutPresenter.SetDrawerLength(presenter, new GridLength(1, GridUnitType.Star));
 				DrawerFlyoutPresenter.SetIsGestureEnabled(presenter, false);
 			}
-
-			// Workaround for https://github.com/unoplatform/uno.chefs/issues/1436
-			// Not explicitly setting thickness causes thickness to be set to a value greater than 1 sometime during runtime
-#if __IOS__
-			presenter.BorderThickness = new Thickness(0);
-#endif
 		}
 	}
 


### PR DESCRIPTION
GitHub Issue (If applicable): 
https://github.com/unoplatform/uno.chefs-archived/issues/36
https://github.com/unoplatform/uno-private/issues/1265

## PR Type

What kind of change does this PR introduce?
- Refactoring (no functional changes, no api changes)


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

No longer need this workaround, as its fixed [here](https://github.com/unoplatform/uno.toolkit.ui/pull/1393)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
