### PR TITLE
chore(UiTest): Remove un-used Fluent Assertion Package Reference

### DIFF
--- a/Chefs.UITests/Chefs.UITests.csproj
+++ b/Chefs.UITests/Chefs.UITests.csproj
@@ -12,7 +12,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="NUnit" VersionOverride="3.14.0" />
-		<PackageReference Include="FluentAssertions" VersionOverride="6.12.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" VersionOverride="17.9.0" />
 		<PackageReference Include="Newtonsoft.Json" VersionOverride="13.0.3" />
 		<PackageReference Include="NUnit3TestAdapter" VersionOverride="4.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Uno.WinUI" Version="2.0.0-rc4.5" />
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.4" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.WinUI" Version="2.0.0-rc4.5" />


### PR DESCRIPTION
dependabot constantly tryes to update the version while this package has become commercial license requiring up from v8.0. If this Package is required again in the future, consider to version pin this to 7.2.0

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)
- Other... Please describe:
    dependabot constantly tryes to update the version while this package has become commercial license requiring up from v8.0.  To avoid running into licensing issues with this, drop this dependency and replace it with e.g. Shouldly or if this Package is really required again in the future, consider to version pin this to 7.2.0
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
unnesseary Package Reference added

## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->
removed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
   Yes, the e.g. Smoke test does not pass, but as there is no using of this Package at all and the issue occuring is caused by not set Property before calling, this PR is not causing this to be happening.
    
    <img width="865" height="309" alt="image" src="https://github.com/user-attachments/assets/4755bb31-0cd6-47a8-8ca8-5297fd3cd462" />

- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results. (see above)
- [x] Contains **NO** breaking changes
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->
tryed to check whats causing the UI Test to fail, but the UITest docs are that much outdated, that they are even telling us to install the [Uno.ProjectTemplates.dotnet](https://www.nuget.org/packages/Uno.ProjectTemplates.Dotnet/4.7.56#versions-body-tab) and have been [last updated ***2 Years ago !***](https://github.com/unoplatform/Uno.UITest/blob/a375f3dc1898e3d34bb03477bb45d2fd86fea60a/doc/using-uno-uitest.md) maybe someone should take a look on this repo again and update the docs, to tell the users of it, when and how to set the App Object to the property. Doing this in the static Testbase Method, does not pass the compiler as the protected property is not allowing to be set from a static method scope via the `AppInitializer.ColdStartApp()` Function return value. Maybe that is needed to be done in

```csharp
namespace Chefs.UITests;

[AutoRetry]
public class Given_WelcomePage : TestBase
{
	[Test]
	public void When_SmokeTest()
	{
		Helpers.Wait(seconds: 3);

		PlatformHelpers.On( //<- this line is the first issued one in the test fail
			iOS: () => App.WaitForElement(q => q.Class("UnoSKMetalView")),
			Android: () => App.WaitForElement(q => q.Class("UnoSKCanvasView")),
			Browser: () => App.WaitForElement(q => q.Id("uno-canvas"))
		);
```
full test result fail:

<img width="960" height="522" alt="image" src="https://github.com/user-attachments/assets/734c80a7-a0b7-49a9-9df9-acea24756a99" />
@kazo0 could you take a look on this?

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
