### PR TITLE
chore: bump uno to 6.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.0.146"
+    "Uno.Sdk": "6.1.23"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
GitHub Issue (If applicable): closes #1644 

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?

- Bump uno sdk version

