### PR TITLE
chore: Bump Uno.Sdk to 6.2

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.1.23"
+    "Uno.Sdk": "6.2.29"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/unoplatform/private/issues/885


## PR Type

What kind of change does this PR introduce?

- Bump Uno.Sdk version to the latest stable version
