### PR TITLE
chore: Bump Uno.Sdk to 6.2 SR1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.2.29"
+    "Uno.Sdk": "6.2.36"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
Bump Uno.Sdk to 6.2 SR1 to include the fix for the SVG issue (https://github.com/unoplatform/uno/issues/21372)