### PR TITLE
chore: Java.Interop.ExportAttribute removal

### DIFF
--- a/Chefs/Chefs.csproj
+++ b/Chefs/Chefs.csproj
@@ -101,6 +101,10 @@
 		<Content Include="Assets\**\*.png" />
 	</ItemGroup>
 
+	<ItemGroup Condition=" $(IsAndroid) And '$(IsUiAutomationMappingEnabled)' == 'True' ">
+		<AndroidJavaSource Include="Platforms\Android\java\chefs\droid\MainActivityExports.java" />
+	</ItemGroup>
+
 	<Target Name="AdjustCalabash" BeforeTargets="BeforeBuild">
 		<!-- Needs to be run as a target, as RuntimeIdentifier is set after the csproj is parsed -->
 		<PropertyGroup Condition="!$(RuntimeIdentifier.Contains('arm64'))">

--- a/Chefs/Platforms/Android/MainActivity.Android.cs
+++ b/Chefs/Platforms/Android/MainActivity.Android.cs
@@ -11,9 +11,11 @@ namespace Chefs.Droid;
 	WindowSoftInputMode = SoftInput.AdjustNothing | SoftInput.StateHidden
 )]
 public class MainActivity : Microsoft.UI.Xaml.ApplicationActivity
+#if USE_UITESTS
+	, IMainActivityExports
+#endif  // USE_UITESTS
 {
 #if USE_UITESTS
-	[Export("GetCurrentPage")]
 	public string GetCurrentPage(string unused) => App.GetCurrentPage();
 #endif
 }

--- a/Chefs/Platforms/Android/java/chefs/droid/MainActivityExports.java
+++ b/Chefs/Platforms/Android/java/chefs/droid/MainActivityExports.java
@@ -1,0 +1,5 @@
+package chefs.droid;
+
+public interface MainActivityExports {
+	String GetCurrentPage(String unused);
+}

--- a/Chefs/Presentation/FilterModel.cs
+++ b/Chefs/Presentation/FilterModel.cs
@@ -14,9 +14,9 @@ public partial record FilterModel
 		Filter = State.Value(this, () => filters);
 	}
 	public IState<SearchFilter> Filter { get; }
-	public IEnumerable<FilterGroup> FilterGroups => Enum.GetValues(typeof(FilterGroup)).Cast<FilterGroup>();
-	public IEnumerable<Time> Times => Enum.GetValues(typeof(Time)).Cast<Time>();
-	public IEnumerable<Difficulty> Difficulties => Enum.GetValues(typeof(Difficulty)).Cast<Difficulty>();
+	public IEnumerable<FilterGroup> FilterGroups => Enum.GetValues<FilterGroup>();
+	public IEnumerable<Time> Times => Enum.GetValues<Time>();
+	public IEnumerable<Difficulty> Difficulties => Enum.GetValues<Difficulty>();
 	public IEnumerable<int> Serves => new int[] { 1, 2, 3, 4, 5 };
 	public IListFeed<Category> Categories => ListFeed.Async(_recipeService.GetCategories);
 

--- a/Chefs/Presentation/SettingsModel.cs
+++ b/Chefs/Presentation/SettingsModel.cs
@@ -29,7 +29,7 @@ public partial record SettingsModel
 	private void OnThemeChanged(object? sender, AppTheme theme) => _messenger.Send(new ThemeChangedMessage(theme));
 
 	public IListFeed<AppTheme> ThemeOptions => State
-		.Value(this, () => Enum.GetValues(typeof(AppTheme)).Cast<AppTheme>().ToImmutableList())
+		.Value(this, () => Enum.GetValues<AppTheme>().ToImmutableList())
 		.AsListFeed()
 		.Selection(Theme);
 


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/commit/4d84ee31adb3e7ecd3fcbdc248b79fee78211d3e

When `Chefs.csproj` is built with
`$(IsUiAutomationMappingEnabled)`=true -- as done in `build/scripts/android-uitest-build.sh` -- *and also* `Chefs.csproj` is built for NativeAOT with .NET 10 RC2:

	dotnet publish -c Release -f net10.0-android -r android-x64 -p:TargetFrameworkOverride=net10.0-android \
	  -p:PublishAot=true -p:UseSkiaRendering=false \
	  -p:AndroidPackageFormat=apk -p:IsUiAutomationMappingEnabled=true -bl Chefs/Chefs.csproj

then the resulting app crashes at startup:

	F DOTNET  : FATAL UNHANDLED EXCEPTION: System.InvalidOperationException: Methods such as __export__ are not implemented!
	F DOTNET  :    at Microsoft.Android.Runtime.ManagedTypeManager.RegisterNativeMembers(JniType, Type, ReadOnlySpan`1) + 0x386
	F DOTNET  :    at Java.Interop.ManagedPeer.RegisterNativeMembers(IntPtr jnienv, IntPtr klass, IntPtr n_nativeClass, IntPtr n_methods) + 0x195

This happens because when `$(IsUiAutomationMappingEnabled)`=true, `USE_UITESTS` is defined, which enables this block within `MainActivity.Android.cs`:

	partial class MainActivity {
	#if USE_UITESTS
	    [Export("GetCurrentPage")]
	    public string GetCurrentPage(string unused) => App.GetCurrentPage();
	#endif
	}

Fix this build configuration by introducing a Java-side `chefs.droid.MainActivityExports` interface and updating `MainActivity` to implement the bound `IMainActivityExports` interface.  This allows us to remove use of `[Java.Interop.ExportAttribute]` while preserving the Java-side method on `MainActivity`.

Additionally, replace use of `Enum.GetValues(Type)` with `Enum.GetValues<T>()`, to fix the linker warnings similar to:

	Chefs/Presentation/SettingsModel.cs(32,22): warning IL3050: Using member 'System.Enum.GetValues(Type)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling.
	  It might not be possible to create an array of the enum type at runtime.
	  Use the GetValues<TEnum> overload or the GetValuesAsUnderlyingType method instead.

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
