### PR TITLE
chore: bump mapsui to stable 5.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Uno.WinUI" Version="2.0.0-rc4.5" />
-    <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0-beta.23" />
+    <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.WinUI" Version="2.0.0-rc4.5" />
     <PackageVersion Include="Mapsui.WinUI" Version="5.0.0-beta.23" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />


### PR DESCRIPTION
closes #1706 

#### PR Classification
This pull request updates a package version to a stable release and includes minor formatting adjustments.

#### PR Summary
This PR updates the `Mapsui.Uno.WinUI` package to its stable version and makes a minor formatting change in the project file.  
- **Directory.Packages.props**: Updated `Mapsui.Uno.WinUI` from `5.0.0-beta.23` to `5.0.0`.  
- **Directory.Packages.props**: Removed an unnecessary line break in the closing `</Project>` tag.  
