### PR TITLE
chore: Support macOS Desktop NativeAOT

### DIFF
--- a/Chefs/Chefs.csproj
+++ b/Chefs/Chefs.csproj
@@ -76,6 +76,138 @@
 	  <EmbeddedResource Include="Assets\Maps\location_circle.svg" />
 	</ItemGroup>
 
+	<ItemGroup>
+
+		<TrimmerRootAssembly Include="BruTile" />
+		<TrimmerRootAssembly Include="BruTile.XmlSerializers" />
+		<TrimmerRootAssembly Include="Chefs" />
+		<TrimmerRootAssembly Include="CommonServiceLocator" />
+		<TrimmerRootAssembly Include="CommunityToolkit.Mvvm" />
+		<TrimmerRootAssembly Include="ExCSS" />
+		<TrimmerRootAssembly Include="HarfBuzzSharp" />
+		<TrimmerRootAssembly Include="LibVLCSharp" />
+		<TrimmerRootAssembly Include="LiveChartsCore" />
+		<TrimmerRootAssembly Include="LiveChartsCore.Behaviours" />
+		<TrimmerRootAssembly Include="LiveChartsCore.SkiaSharpView" />
+		<TrimmerRootAssembly Include="LiveChartsCore.SkiaSharpView.Uno.WinUI" />
+		<TrimmerRootAssembly Include="Mapsui" />
+		<TrimmerRootAssembly Include="Mapsui.Nts" />
+		<TrimmerRootAssembly Include="Mapsui.Rendering.Skia" />
+		<TrimmerRootAssembly Include="Mapsui.Tiling" />
+		<TrimmerRootAssembly Include="Mapsui.UI.Uno.WinUI" />
+		<TrimmerRootAssembly Include="Microsoft.Bcl.AsyncInterfaces" />
+		<TrimmerRootAssembly Include="Microsoft.CSharp" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.Binder" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.CommandLine" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.FileExtensions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.Json" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Configuration.UserSecrets" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.DependencyInjection" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Diagnostics" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Diagnostics.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.FileProviders.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.FileProviders.Physical" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.FileSystemGlobbing" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Hosting" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Hosting.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Http" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Localization.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.Configuration" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.Console" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.Debug" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.EventLog" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Logging.EventSource" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Options" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
+		<TrimmerRootAssembly Include="Microsoft.Extensions.Primitives" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Abstractions" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Http.HttpClientLibrary" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Serialization.Form" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Serialization.Json" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Serialization.Multipart" />
+		<TrimmerRootAssembly Include="Microsoft.Kiota.Serialization.Text" />
+		<TrimmerRootAssembly Include="Microsoft.VisualBasic" />
+		<TrimmerRootAssembly Include="Microsoft.VisualBasic.Core" />
+		<TrimmerRootAssembly Include="Microsoft.Win32.Primitives" />
+		<TrimmerRootAssembly Include="Microsoft.Win32.Registry" />
+		<TrimmerRootAssembly Include="NetTopologySuite" />
+		<TrimmerRootAssembly Include="NetTopologySuite.Features" />
+		<TrimmerRootAssembly Include="NetTopologySuite.IO.GeoJSON4STJ" />
+		<TrimmerRootAssembly Include="Refit" />
+		<TrimmerRootAssembly Include="ShimSkiaSharp" />
+		<TrimmerRootAssembly Include="SkiaSharp" />
+		<TrimmerRootAssembly Include="SkiaSharp.HarfBuzz" />
+		<TrimmerRootAssembly Include="SkiaSharp.Resources" />
+		<TrimmerRootAssembly Include="SkiaSharp.SceneGraph" />
+		<TrimmerRootAssembly Include="SkiaSharp.Skottie" />
+		<TrimmerRootAssembly Include="SkiaSharp.Views.Windows" />
+		<TrimmerRootAssembly Include="Std.UriTemplate" />
+		<TrimmerRootAssembly Include="Svg.Custom" />
+		<TrimmerRootAssembly Include="Svg.Model" />
+		<TrimmerRootAssembly Include="Svg.Skia" />
+		<TrimmerRootAssembly Include="Uno" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions.Collections" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions.Disposables" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions.Equality" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions.Logging" />
+		<TrimmerRootAssembly Include="Uno.Core.Extensions.Logging.Singleton" />
+		<TrimmerRootAssembly Include="Uno.Diagnostics.Eventing" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Authentication" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Authentication.UI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Configuration" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Core" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Core.UI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Hosting" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Hosting.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Http" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Http.Kiota" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Http.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Localization" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Localization.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Logging.WebAssembly.Console" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Logging.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Navigation" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Navigation.Toolkit.UI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Navigation.UI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Reactive" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Reactive.Messaging" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Reactive.UI" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Serialization" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Serialization.Http" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Serialization.Refit" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Storage" />
+		<TrimmerRootAssembly Include="Uno.Extensions.Storage.UI" />
+		<TrimmerRootAssembly Include="Uno.Fonts.Fluent" />
+		<TrimmerRootAssembly Include="Uno.Fonts.OpenSans" />
+		<TrimmerRootAssembly Include="Uno.Fonts.Roboto" />
+		<TrimmerRootAssembly Include="Uno.Foundation" />
+		<TrimmerRootAssembly Include="Uno.Foundation.Logging" />
+		<TrimmerRootAssembly Include="Uno.Material.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Themes.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Toolkit" />
+		<TrimmerRootAssembly Include="Uno.Toolkit.Skia.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Toolkit.WinUI" />
+		<TrimmerRootAssembly Include="Uno.Toolkit.WinUI.Material" />
+		<TrimmerRootAssembly Include="Uno.UI" />
+		<TrimmerRootAssembly Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" />
+		<TrimmerRootAssembly Include="Uno.UI.Composition" />
+		<TrimmerRootAssembly Include="Uno.UI.Dispatching" />
+		<TrimmerRootAssembly Include="Uno.UI.FluentTheme" />
+		<TrimmerRootAssembly Include="Uno.UI.FluentTheme.v1" />
+		<TrimmerRootAssembly Include="Uno.UI.FluentTheme.v2" />
+		<TrimmerRootAssembly Include="Uno.UI.Lottie" />
+		<TrimmerRootAssembly Include="Uno.UI.Toolkit" />
+		<TrimmerRootAssembly Include="Uno.WinUI.Graphics2DSK" />
+		<TrimmerRootAssembly Include="Uno.Xaml" />
+	</ItemGroup>
+
 	<PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(IsUiAutomationMappingEnabled)'=='True'">
 		<IsUiAutomationMappingEnabled>True</IsUiAutomationMappingEnabled>
 		<DefineConstants>$(DefineConstants);USE_UITESTS</DefineConstants>
@@ -109,6 +241,10 @@
 		<!-- Needs to be run as a target, as RuntimeIdentifier is set after the csproj is parsed -->
 		<PropertyGroup Condition="!$(RuntimeIdentifier.Contains('arm64'))">
 			<DefineConstants>$(DefineConstants);HAS_TESTCLOUD_AGENT</DefineConstants>
+		</PropertyGroup>
+		<PropertyGroup Condition=" '$(RuntimeIdentifier)' != '' ">
+			<DefineConstants>$(DefineConstants);RUNTIME_IDENTIFIER_$(RuntimeIdentifier.Replace('-', '_').ToUpperInvariant())</DefineConstants>
+			<DefineConstants Condition=" $(RuntimeIdentifier.Contains('-')) ">$(DefineConstants);RUNTIME_IDENTIFIER_$(RuntimeIdentifier.Substring(0, $(RuntimeIdentifier.IndexOf('-'))).ToUpperInvariant())</DefineConstants>
 		</PropertyGroup>
 	</Target>
 

--- a/Chefs/Platforms/Desktop/Program.cs
+++ b/Chefs/Platforms/Desktop/Program.cs
@@ -7,12 +7,16 @@ public class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        App.InitializeLogging();
+
         var host = UnoPlatformHostBuilder.Create()
             .App(() => new App())
             .UseX11()
             .UseLinuxFrameBuffer()
             .UseMacOS()
+#if RUNTIME_IDENTIFIER_WIN
             .UseWin32()
+#endif  // RUNTIME_IDENTIFIER_WIN
             .Build();
 
         host.Run();


### PR DESCRIPTION
Context: https://github.com/unoplatform/uno/commit/1003d8cf5ae9b5e6dbb2e0148a41a4a7c04fa40a

What do we want?  NativeAOT support!

Where do we want it!  Desktop macOS?

(It works for Android, how hard could desktop macOS be?)

*Allow* building with .NET 10 RC2:

	cat >patch <<EOF
	diff --git a/Chefs/Chefs.csproj b/Chefs/Chefs.csproj
	index b1fc80fc..4e181980 100644
	--- a/Chefs/Chefs.csproj
	+++ b/Chefs/Chefs.csproj
	@@ -1,4 +1,4 @@
	-﻿<Project Sdk="Uno.Sdk">
	+﻿<Project Sdk="Uno.Sdk.Private">
	 	<PropertyGroup>
	 		<!-- Building with dotnet build -f net9.0-platform will still cause restore to happen for all TargetFrameworks -->
	 		<!-- which will force us to install all workloads even if not needed -->
	diff --git a/global.json b/global.json
	index 7f65a2cc..36721321 100644
	--- a/global.json
	+++ b/global.json
	@@ -1,8 +1,8 @@
	 {
	   "msbuild-sdks": {
	-    "Uno.Sdk": "6.3.28"
	+    "Uno.Sdk.Private": "6.4.0-dev.244"
	   },
	   "sdk": {
	-    "allowPrerelease": false
	+    "allowPrerelease": true
	   }
	 }
	EOF
	git apply < patch

Build it with .NET 10 RC2:

	dotnet publish -c Release -r osx-x64 \
	  -f net10.0-desktop -p:TargetFrameworkOverride=net10.0-desktop \
	  -p:SelfContained=true -p:PublishAot=true -p:UseSkiaRendering=true \
	  Chefs/Chefs.csproj -bl

Run it:

	Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

Watch it blow up (?!):

	Unhandled exception. System.DllNotFoundException: Unable to load shared library 'USER32.dll' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable:
	dlopen(…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll.dylib, 0x0001): tried: '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll.dylib' (no such file), '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll.dylib' (no such file)
	dlopen(USER32.dll.dylib, 0x0001): tried: 'USER32.dll.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSUSER32.dll.dylib' (no such file), '/usr/lib/USER32.dll.dylib' (no such file, not in dyld cache), 'USER32.dll.dylib' (no such file)
	dlopen(…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll.dylib, 0x0001): tried: '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll.dylib' (no such file), '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll.dylib' (no such file)
	dlopen(libUSER32.dll.dylib, 0x0001): tried: 'libUSER32.dll.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibUSER32.dll.dylib' (no such file), '/usr/lib/libUSER32.dll.dylib' (no such file, not in dyld cache), 'libUSER32.dll.dylib' (no such file)
	dlopen(…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll, 0x0001): tried: '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OS…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll' (no such file), '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/USER32.dll' (no such file)
	dlopen(USER32.dll, 0x0001): tried: 'USER32.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OSUSER32.dll' (no such file), '/usr/lib/USER32.dll' (no such file, not in dyld cache), 'USER32.dll' (no such file)
	dlopen(…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll, 0x0001): tried: '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OS…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll' (no such file), '…/uno.chefs/Chefs/bin/Release/net10.0-desktop/osx-x64/publish/libUSER32.dll' (no such file)
	dlopen(libUSER32.dll, 0x0001): tried: 'libUSER32.dll' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibUSER32.dll' (no such file), '/usr/lib/libUSER32.dll' (no such file, not in dyld cache), 'libUSER32.dll' (no such file)

	   at System.Runtime.InteropServices.NativeLibrary.LoadLibErrorTracker.Throw(String) + 0x46
	   at Internal.Runtime.CompilerHelpers.InteropHelpers.FixupModuleCell(InteropHelpers.ModuleFixupCell*) + 0x12c
	   at Internal.Runtime.CompilerHelpers.InteropHelpers.ResolvePInvokeSlow(InteropHelpers.MethodFixupCell*) + 0x35
	   at Windows.Win32.PInvoke.<SetProcessDpiAwarenessContext>g__LocalExternFunction|247_0(DPI_AWARENESS_CONTEXT) + 0x22
	   at Windows.Win32.PInvoke.SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT) + 0x1b
	   at DpiBootstrap.Init() + 0x10
	   at Internal.Runtime.CompilerHelpers.StartupCodeHelpers.RunInitializers(TypeManagerHandle, ReadyToRunSectionType) + 0x45
	   at Internal.Runtime.CompilerHelpers.StartupCodeHelpers.RunModuleInitializers() + 0x37
	zsh: abort      Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs

What's happening is:

 1. unoplatform/uno@1003d8cf introduced the use of module initializers into `Uno.UI.Runtime.Skia.Win32.Support.dll`.

 2. *Because* `Program.cs` has a `.UseWin32()` method invocation, there is (eventually) an assembly reference to `Uno.UI.Runtime.Skia.Win32.Support.dll`.

 3. Under NativeAOT, [module initializers are run during startup][0]. ***All*** of them.

Which means that when building a NativeAOT app for macOS, the module initializers from `Uno.UI.Runtime.Skia.Win32.Support.dll` are executed.

The "fix" (workaround) is to *remove* the call to `.UseWin32()`.

(A *better* fix would be to remove the module initializer, maybe?)

Update the `AdjustCalabash` target to update `$(DefineConstants)` based on the `$(RuntimeIdentifier)` value, when set, so that it contains a "#define-safe" `RUNTIME_IDENTIFIER_`-prefixed value based on `$(RuntimeIdentifier)`.  For example, in `dotnet build -r osx-x64`, both `RUNTIME_IDENTIFIER_OSX` and `RUNTIME_IDENTIFIER_OSX_X64` will be defined during compilation.

See also the [.NET RID Catalog][1], from which we see that the `$(RuntimeIdentifier)` values for Windows begin with `win-`.

Surround the `.UseWin32()` invocation with `RUNTIME_IDENTIFIER_WIN`, so that it isn't called when running on e.g. macOS.

That fixes the `DllNotFoundException`.

The next problem is that, while it no longer crashes, it doesn't *show* anything either.

Update `Program.cs` to call `App.InitializeLogging()`, so that we can see log messages printed to `stdout`.

*Now* we can see the next problem:

	System.InvalidOperationException: A suitable constructor for type 'Uno.Extensions.Navigation.Navigators.ContentControlNavigator' could not be located.
	  Ensure the type is concrete and services are registered for all parameters of a public constructor.
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache, ServiceIdentifier, Type, CallSiteChain) + 0x3e9
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor, ServiceIdentifier, CallSiteChain, Int32) + 0x181
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceIdentifier, CallSiteChain) + 0x14f
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain) + 0xc9
	   at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceIdentifier, CallSiteChain) + 0x92
	   at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier) + 0x68
	   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey, Func`2) + 0xd2
	   at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier, ServiceProviderEngineScope) + 0x39
	   at Uno.Extensions.Navigation.NavigatorFactory.CreateService(IRegion) + 0xe2
	   at Uno.Extensions.Navigation.Regions.NavigationRegion.InitializeRootRegion(IServiceProvider) + 0x61
	   at Uno.Extensions.Navigation.Regions.NavigationRegion..ctor(ILogger, FrameworkElement, IServiceProvider) + 0x2ee
	   at Uno.Extensions.Navigation.FrameworkElementExtensions.HostAsync(FrameworkElement, IServiceProvider, String, Type, Type, Func`3) + 0xbc
	   at Uno.Extensions.ServiceProviderExtensions.<BuildAndInitializeHostAsync>d__5.MoveNext() + 0x18f

Which is where everything goes off the rails: the Chefs app is quite dynamic, whereas NativeAOT *isn't*; the trimmer is removing lots of "necessary" code.

Square that circle by (more or less) preserving "everything": add a `@(TrimmerRootAssembly)` item group which lists (almost) everything that the trimmer needs to preserve.  (And then some.  This is *not* a minimal group; this is the "biggest small" group I could get building and running properly in a short timeframe.  It likely can be shrunk.)

Notably absent: everything that references
`Uno.UI.Runtime.Skia.Win32.Support.dll` (need to allow the app to start!), all `System` assemblies, lots of `Microsoft.*` assemblies…

*Now* the app is able to launch and run correctly.

…but at what cost?

`Chefs/bin/Release/net10.0-desktop/osx-x64/publish/Chefs` is a 121MB binary.

The `Chefs/bin/Release/net10.0-desktop/osx-x64/publish` directory is 810MB in size, though that also contains artifacts that don't appear relevant for macOS, e.g. `libvlc/win-x64`; the `libvlc` directory is 197MB, and doesn't immediately appear to be needed (i.e. the app launches and is usable if `libvlc` doesn't exist).

Compare to a `-p:SelfContained=true` build which *doesn't* use NativeAOT, and we get:

| Configuration                               |          `Chefs` size |  `publish` size |
| ------------------------------------------- | --------------------: | --------------: |
| `-p:SelfContained=true`                     |        92856 <br> 91K |            444M |
| `-p:SelfContained=true -p:PublishAot=true`  |   126703200 <br> 121M |            810M |

The non-NativeAOT build *also* contains a `libvlc` directory…

The next obvious question is "what does startup look like?" Unfortunately that information doesn't appear to be collected by the operating system, so I either use a stopwatch (lol) or by "feels". NativeAOT "feels" faster, but it's not dramatic.  It feels hundredths of a second faster to start and react to button clicks.

[0]: https://github.com/dotnet/runtime/blob/b1cb4c502f1eec66227a31e705934fb67fc091f0/src/coreclr/nativeaot/Common/src/Internal/Runtime/CompilerHelpers/StartupCodeHelpers.cs#L163-L169]
[1]: https://learn.microsoft.com/en-us/dotnet/core/rid-catalog

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
