### PR TITLE
ci: Update android uitest emulator config

### DIFF
--- a/Chefs.UITests/Constants.cs
+++ b/Chefs.UITests/Constants.cs
@@ -1,15 +1,15 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Uno.UITest.Helpers.Queries;
 
 namespace Chefs.UITests;
 
 public class Constants
 {
-	public readonly static string ApplicationId = "uno.platform.chefs.skia";
+	private const string DefaultApplicationId = "uno.platform.chefs.skia";
+	private const string AppIdEnvVar = "UNO_UITEST_APP_ID";
+
+	public readonly static string ApplicationId =
+		Environment.GetEnvironmentVariable(AppIdEnvVar) ?? DefaultApplicationId;
 
 	public readonly static string WebAssemblyDefaultUri = "http://localhost:51480/";
 	public readonly static string iOSAppName = ApplicationId;

--- a/build/scripts/android-uitest-run.sh
+++ b/build/scripts/android-uitest-run.sh
@@ -11,9 +11,11 @@ else
 	export APK_NAME="uno.platform.chefs.skia"
 fi
 
+export UNO_UITEST_APP_ID="$APK_NAME"
+
 export BUILDCONFIGURATION=Release
 export UNO_UITEST_PLATFORM=Android
-export ANDROID_SIMULATOR_APILEVEL=28
+export ANDROID_SIMULATOR_APILEVEL=34
 
 
 export UNO_UITEST_ANDROID_PROJECT_PATH=$BUILD_SOURCESDIRECTORY/Chefs
@@ -96,7 +98,7 @@ install_android_sdk() {
 
 		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'tools'| tr '\r' '\n' | uniq
 		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'platform-tools'  | tr '\r' '\n' | uniq
-		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'build-tools;35.0.0' | tr '\r' '\n' | uniq
+		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'build-tools;36.0.0' | tr '\r' '\n' | uniq
 		echo "y" | $LATEST_CMDLINE_TOOLS_PATH/bin/sdkmanager --sdk_root=${ANDROID_HOME} --install 'extras;android;m2repository' | tr '\r' '\n' | uniq
 	fi
 	
@@ -115,6 +117,7 @@ then
 	install_android_sdk $ANDROID_SIMULATOR_APILEVEL
 	install_android_sdk 34
 	install_android_sdk 35
+	install_android_sdk 36
 
 	if [[ -f $ANDROID_HOME/platform-tools/platform-tools/adb ]]
 	then

--- a/build/workflow/build-android.yml
+++ b/build/workflow/build-android.yml
@@ -17,11 +17,6 @@ jobs:
   - template: templates/canary-updater.yml
 
   - bash: |
-      dotnet workload restore $(build.sourcesdirectory)/Chefs/Chefs.csproj
-    displayName: Restore Android workloads
-    retryCountOnTaskFailure: 3
-
-  - bash: |
       chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
       $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
     displayName: Build Android App for UI Tests

--- a/build/workflow/build-android.yml
+++ b/build/workflow/build-android.yml
@@ -17,6 +17,11 @@ jobs:
   - template: templates/canary-updater.yml
 
   - bash: |
+      dotnet workload restore $(build.sourcesdirectory)/Chefs/Chefs.csproj
+    displayName: Restore Android workloads
+    retryCountOnTaskFailure: 3
+
+  - bash: |
       chmod +x $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
       $(build.sourcesdirectory)/build/scripts/android-uitest-build.sh
     displayName: Build Android App for UI Tests

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Uno.Sdk": "6.4.53"
+    "Uno.Sdk": "6.5.29"
   },
   "sdk": {
     "allowPrerelease": false


### PR DESCRIPTION
Updates the Android UI test runner to use a newer emulator API level and build-tools, and exports the app id for consistent tooling behavior. This reduces flaky startup failures in the emulator on macOS agents. 

Note: No related issue (Internal maintenance / Approved by Team member: @agneszitte).