### PR TITLE
fix(ci): add Linux host disk cleanup for CI builds

### DIFF
--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,0 +1,19 @@
+name: 'Host Cleanup (Linux)'
+description: 'Remove unused toolchains and SDKs to free disk space on Linux runners'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Cleanup unused image dependencies
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        echo "Disk space before cleanup:"
+        df -h /
+        rm -fR ~/.cargo ~/.rustup ~/.dotnet
+        sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        sudo snap remove lxd || true
+        sudo snap remove core20 || true
+        sudo apt remove -y snapd || true
+        echo "Disk space after cleanup:"
+        df -h /

--- a/.github/actions/host-cleanup-linux/action.yml
+++ b/.github/actions/host-cleanup-linux/action.yml
@@ -1,19 +1,10 @@
-name: 'Host Cleanup (Linux)'
-description: 'Remove unused toolchains and SDKs to free disk space on Linux runners'
+name: Host Cleanup (Linux)
+description: Reclaims disk space on Linux CI agents by removing unused pre-installed software
 
 runs:
   using: 'composite'
   steps:
-    - name: Cleanup unused image dependencies
+    - name: Cleanup unused host dependencies
       if: runner.os == 'Linux'
       shell: bash
-      run: |
-        echo "Disk space before cleanup:"
-        df -h /
-        rm -fR ~/.cargo ~/.rustup ~/.dotnet
-        sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-        sudo snap remove lxd || true
-        sudo snap remove core20 || true
-        sudo apt remove -y snapd || true
-        echo "Disk space after cleanup:"
-        df -h /
+      run: bash "$GITHUB_WORKSPACE/build/workflow/scripts/host-cleanup-linux.sh"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 0 # Required for gitversion
           submodules: true
 
+      - name: Free disk space (Linux)
+        uses: ./.github/actions/host-cleanup-linux
+
       - name: Setup dotnet 9.0.101
         uses: actions/setup-dotnet@v1.7.2
         with:

--- a/build/workflow/build-wasm.yml
+++ b/build/workflow/build-wasm.yml
@@ -16,27 +16,8 @@ jobs:
     fetchDepth: 0
     persistCredentials: true
 
-  - bash: |
-      # This list is based on what the base image contains and
-      # may need to be adjusted as new software gets installed.
-      # Use the `du` command below to determine what can be
-      # uninstalled.
-      
-      rm -fR ~/.cargo
-      rm -fR ~/.rustup
-      rm -fR ~/.dotnet
-      sudo rm -fR /usr/share/swift
-      sudo rm -fR /opt/microsoft/msedge
-      sudo rm -fR /usr/local/.ghcup
-      sudo rm -fR /usr/lib/mono
-      sudo snap remove lxd
-      sudo snap remove core20
-      sudo apt remove snapd
+  - template: templates/host-cleanup-linux.yml
 
-      df -h
-      # du -h -d 3 /
-    displayName: 'Cleanup unused image dependencies (Linux)'
-    condition: eq(variables['Agent.OS'], 'Linux')
   - task: UseDotNet@2
     retryCountOnTaskFailure: 3
     inputs:

--- a/build/workflow/scripts/host-cleanup-linux.sh
+++ b/build/workflow/scripts/host-cleanup-linux.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Reclaims disk space on Linux CI agents by removing pre-installed
+# software that is not needed for the build.
+#
+# This list is based on what the base image contains and
+# may need to be adjusted as new software gets installed.
+# Use the `du` command to determine what can be uninstalled.
+
+# Use sudo only when available (containers may not have it)
+if command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+echo "Disk space before cleanup:"
+df -h /
+
+rm -rf ~/.cargo ~/.rustup ~/.dotnet
+
+$SUDO rm -rf /usr/share/swift || true
+$SUDO rm -rf /opt/microsoft/msedge || true
+$SUDO rm -rf /usr/local/.ghcup || true
+$SUDO rm -rf /usr/lib/mono || true
+$SUDO rm -rf /usr/local/lib/android || true
+$SUDO rm -rf /opt/ghc || true
+$SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
+
+$SUDO snap remove lxd || true
+$SUDO snap remove core20 || true
+$SUDO apt-get purge -y snapd || true
+
+echo "Disk space after cleanup:"
+df -h /

--- a/build/workflow/scripts/host-cleanup-linux.sh
+++ b/build/workflow/scripts/host-cleanup-linux.sh
@@ -6,9 +6,9 @@
 # may need to be adjusted as new software gets installed.
 # Use the `du` command to determine what can be uninstalled.
 
-# Use sudo only when available (containers may not have it)
-if command -v sudo >/dev/null 2>&1; then
-  SUDO="sudo"
+# Use sudo only when available and non-interactive (no password prompt)
+if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+  SUDO="sudo -n"
 else
   SUDO=""
 fi
@@ -16,7 +16,7 @@ fi
 echo "Disk space before cleanup:"
 df -h /
 
-rm -rf ~/.cargo ~/.rustup ~/.dotnet
+rm -rf ~/.cargo ~/.rustup ~/.dotnet || true
 
 $SUDO rm -rf /usr/share/swift || true
 $SUDO rm -rf /opt/microsoft/msedge || true
@@ -26,9 +26,14 @@ $SUDO rm -rf /usr/local/lib/android || true
 $SUDO rm -rf /opt/ghc || true
 $SUDO rm -rf /opt/hostedtoolcache/CodeQL || true
 
-$SUDO snap remove lxd || true
-$SUDO snap remove core20 || true
-$SUDO apt-get purge -y snapd || true
+if command -v snap >/dev/null 2>&1; then
+  timeout 60s $SUDO snap remove lxd || true
+  timeout 60s $SUDO snap remove core20 || true
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  DEBIAN_FRONTEND=noninteractive timeout 120s $SUDO apt-get purge -y snapd || true
+fi
 
 echo "Disk space after cleanup:"
 df -h /

--- a/build/workflow/stage-uitests-wasm.yml
+++ b/build/workflow/stage-uitests-wasm.yml
@@ -7,6 +7,8 @@ jobs:
     vmImage: ubuntu-latest
 
   steps:
+  - template: templates/host-cleanup-linux.yml
+
   - task: NodeTool@0
     inputs:
       versionSource: 'spec'

--- a/build/workflow/templates/host-cleanup-linux.yml
+++ b/build/workflow/templates/host-cleanup-linux.yml
@@ -1,0 +1,15 @@
+steps:
+  - bash: |
+      echo "Disk space before cleanup:"
+      df -h /
+
+      rm -fR ~/.cargo ~/.rustup ~/.dotnet
+      sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+      sudo snap remove lxd || true
+      sudo snap remove core20 || true
+      sudo apt remove -y snapd || true
+
+      echo "Disk space after cleanup:"
+      df -h /
+    displayName: Cleanup unused host dependencies
+    condition: eq(variables['Agent.OS'], 'Linux')

--- a/build/workflow/templates/host-cleanup-linux.yml
+++ b/build/workflow/templates/host-cleanup-linux.yml
@@ -1,15 +1,7 @@
+# Reusable AzDO template: Cleanup unused dependencies on Linux CI agents.
+# Calls the shared host-cleanup-linux.sh script to avoid duplication with GitHub Actions.
 steps:
   - bash: |
-      echo "Disk space before cleanup:"
-      df -h /
-
-      rm -fR ~/.cargo ~/.rustup ~/.dotnet
-      sudo rm -fR /usr/share/swift /opt/microsoft/msedge /usr/local/.ghcup /usr/lib/mono /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-      sudo snap remove lxd || true
-      sudo snap remove core20 || true
-      sudo apt remove -y snapd || true
-
-      echo "Disk space after cleanup:"
-      df -h /
+      bash "$(Build.SourcesDirectory)/build/workflow/scripts/host-cleanup-linux.sh"
     displayName: Cleanup unused host dependencies
     condition: eq(variables['Agent.OS'], 'Linux')


### PR DESCRIPTION
## What
Adds a Linux host disk cleanup step to all Linux CI jobs to reclaim disk space by removing unused pre-installed software.

## Why
Linux CI agents accumulate ~20–30 GB of pre-installed software (Cargo, Rust, Swift, Edge, GHC, Mono, Android SDK, CodeQL, snapd) that is not needed for builds. This cleanup step runs at the start of each Linux job to ensure sufficient disk space.

## Details
- Adds a shared shell script (`host-cleanup-linux.sh`) called by both the AzDO template and GHA composite action
- Cleanup is conditional on Linux (`condition: eq(variables['Agent.OS'], 'Linux')` / `if: runner.os == 'Linux'`)
- Uses `sudo -n` (non-interactive) probe to work safely in both host and container environments
- All removals are best-effort (`|| true`) with `timeout` guards on snap/apt-get commands
- Uses `DEBIAN_FRONTEND=noninteractive` for apt-get to prevent dpkg prompts

Part of org-wide CI disk cleanup initiative.
Related to https://github.com/unoplatform/uno.rider/pull/480