### PR TITLE
ci(canary): bump nuget.updater to 1.3.1

### DIFF
--- a/build/workflow/templates/canary-updater.yml
+++ b/build/workflow/templates/canary-updater.yml
@@ -21,7 +21,7 @@ steps:
       useNuGetOrg: true
       mergeBranch: true
       branchToMerge: main
-      nugetUpdaterVersion: '1.2.10'
+      nugetUpdaterVersion: '1.3.1'
       packageAuthor: 'unoplatform,uno platform'
       summaryFile: '$(Build.ArtifactStagingDirectory)/Summary.md'
       resultFile: '$(Build.ArtifactStagingDirectory)/Results.json'


### PR DESCRIPTION
Bumps the canary `nuget.updater` to **1.3.1** for consistency with the other canaries (Gallery / Themes / Toolkit / Rider / Studio / extensions all on 1.3.1) and to pick up the property-package fallback fix.

Single-source-of-truth on the default branch; once merged, `canaries/dev` will be synced with `main`.