### PR TITLE
chore: fix InvalidOperationException from iOS App startup

### DIFF
--- a/Chefs/Chefs.csproj
+++ b/Chefs/Chefs.csproj
@@ -25,7 +25,6 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 		<UseMocks Condition="'$(UseMocks)'==''">true</UseMocks>
-		<IsAotCompatible>true</IsAotCompatible>
 		<PublishAot Condition=" '$(SkiaPublishAot)' == 'true' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">true</PublishAot>
 		<PublishAot Condition=" '$(SkiaPublishAot)' == 'true' And $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">true</PublishAot>
 		<PublishAot Condition=" '$(PublishAot)' == '' And '$(SkiaPublishAot)' != '' ">$(SkiaPublishAot)</PublishAot>


### PR DESCRIPTION
Context: e838af9451b107bafaa56dfcd64957a11eda0f0c

Commit e838af94 broke Chefs startup on iOS.  Tapping the icon would result in the splash screen being shown, then replaced with a blank screen (white or black).

If you open **Console.app**, attach to the iOS device, stream messages, and filter by `Process:Chefs`, you will see the following exception:

	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.InvalidOperationException: NoConstructorMatch, Chefs.Presentation.ShellViewModel
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache lifetime, ServiceIdentifier serviceIdentifier, Type implementationType, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
	fail: Uno.UI.Dispatching.NativeDispatcher[0]
	      NativeDispatcher unhandled exception
	      System.InvalidOperationException: NoConstructorMatch, Chefs.Presentation.ShellViewModel
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateConstructorCallSite(ResultCache lifetime, ServiceIdentifier serviceIdentifier, Type implementationType, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceDescriptor descriptor, ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain, Int32 slot)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateExact(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.CreateCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.GetCallSite(ServiceIdentifier serviceIdentifier, CallSiteChain callSiteChain)
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.CreateServiceAccessor(ServiceIdentifier serviceIdentifier)
	         at System.Collections.Concurrent.ConcurrentDictionary`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceIdentifier, Microsoft.Extensions.DependencyInjection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[Microsoft.Extensions.DependencyInjection.ServiceProvider.ServiceAccessor, Microsoft.Extensions.DependencyInjection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].GetOrAdd(ServiceIdentifier , Func`2 )
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass8_0.<<CreateViewModel>b__0>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.CreateViewModel(IServiceProvider services, NavigationRequest request, Route route, RouteInfo mapping)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator`1.<InitializeCurrentView>d__9[[Microsoft.UI.Xaml.Controls.ContentControl, Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator`1.<ExecuteRequestAsync>d__8[[Microsoft.UI.Xaml.Controls.ContentControl, Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.ControlNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass4_0.<<ControlCoreNavigateAsync>b__0>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.DispatcherExtensions.<>c__DisplayClass2_0`1.<<ExecuteAsync>b__0>d[[Uno.Extensions.Navigation.NavigationResponse, Uno.Extensions.Navigation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Dispatcher.<ExecuteAsync>d__4`1[[Uno.Extensions.Navigation.NavigationResponse, Uno.Extensions.Navigation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at System.Collections.Concurrent.ConcurrentDictionary`2[[Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceIdentifier, Microsoft.Extensions.DependencyInjection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60],[Microsoft.Extensions.DependencyInjection.ServiceProvider.ServiceAccessor, Microsoft.Extensions.DependencyInjection, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60]].GetOrAdd(ServiceIdentifier , Func`2 )
	         at Microsoft.Extensions.DependencyInjection.ServiceProvider.GetService(ServiceIdentifier serviceIdentifier, ServiceProviderEngineScope serviceProviderEngineScope)
	         at Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceProviderEngineScope.GetService(Type serviceType)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass8_0.<<CreateViewModel>b__0>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.CreateViewModel(IServiceProvider services, NavigationRequest request, Route route, RouteInfo mapping)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator`1.<InitializeCurrentView>d__9[[Microsoft.UI.Xaml.Controls.ContentControl, Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator`1.<ExecuteRequestAsync>d__8[[Microsoft.UI.Xaml.Controls.ContentControl, Uno.UI, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.ControlNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.<>c__DisplayClass4_0.<<ControlCoreNavigateAsync>b__0>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.DispatcherExtensions.<>c__DisplayClass2_0`1.<<ExecuteAsync>b__0>d[[Uno.Extensions.Navigation.NavigationResponse, Uno.Extensions.Navigation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Dispatcher.<ExecuteAsync>d__4`1[[Uno.Extensions.Navigation.NavigationResponse, Uno.Extensions.Navigation, Version=255.255.255.255, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.ControlCoreNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.CoreNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigator.RegionNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigator.NavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.FrameworkElementExtensions.<>c__DisplayClass1_1.<<HostAsync>b__6>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.FrameworkElementExtensions.Startup(IServiceProvider services, Func`1 afterStartup)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.ControlCoreNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigators.ControlNavigator.CoreNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigator.RegionNavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.Navigator.NavigateAsync(NavigationRequest request)
	         at Uno.Extensions.Navigation.FrameworkElementExtensions.<>c__DisplayClass1_1.<<HostAsync>b__6>d.MoveNext()
	      --- End of stack trace from previous location ---
	         at Uno.Extensions.Navigation.FrameworkElementExtensions.Startup(IServiceProvider services, Func`1 afterStartup)
	         at Uno.Extensions.ServiceProviderExtensions.BuildAndInitializeHostAsync(Window window, FrameworkElement viewHost, Func`1 buildHost, String initialRoute, Type initialView, Type initialViewModel, Func`3 initialNavigate)
	         at Uno.Extensions.ApplicationBuilderExtensions.<NavigateAsync>d__0`1[[Chefs.Views.ShellControl, Chefs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Chefs.App.OnLaunched(LaunchActivatedEventArgs )
	         at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state)
	         at Uno.UI.Dispatching.NativeDispatcherSynchronizationContext.<>c__DisplayClass3_0.<Post>b__0()
	         at Uno.UI.Dispatching.NativeDispatcher.RunAction(NativeDispatcher , Action )
	         at Uno.Extensions.ServiceProviderExtensions.BuildAndInitializeHostAsync(Window window, FrameworkElement viewHost, Func`1 buildHost, String initialRoute, Type initialView, Type initialViewModel, Func`3 initialNavigate)
	         at Uno.Extensions.ApplicationBuilderExtensions.<NavigateAsync>d__0`1[[Chefs.Views.ShellControl, Chefs, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].MoveNext()
	         at Chefs.App.OnLaunched(LaunchActivatedEventArgs )
	         at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__124_0(Object state)
	         at Uno.UI.Dispatching.NativeDispatcherSynchronizationContext.<>c__DisplayClass3_0.<Post>b__0()
	         at Uno.UI.Dispatching.NativeDispatcher.RunAction(NativeDispatcher , Action )

The `ShellViewModel` constructor is missing!

For further verification, try:

	ildasm Chefs/obj/Release/net9.0-ios/ios-arm64/ipa/Payload/Chefs.app/Chefs.dll

which showed:

	.class public auto ansi sealed beforefieldinit Chefs.Presentation.ShellViewModel
	       extends [Uno.Extensions.Reactive]Uno.Extensions.Reactive.Bindings.BindableViewModelBase
	{
	  .custom instance void [Uno.Extensions.Reactive]Uno.Extensions.Reactive.Bindings.BindableAttribute::.ctor(class [System.Private.CoreLib]System.Type) = ( 01 00 1D 43 68 65 66 73 2E 50 72 65 73 65 6E 74   // ...Chefs.Present
	                                                                                                                                                          61 74 69 6F 6E 2E 53 68 65 6C 6C 4D 6F 64 65 6C   // ation.ShellModel
	                                                                                                                                                          00 00 )
	  .method family hidebysig virtual final
	          instance void  __Reactive_UpdateModel(object A_1) cil managed noinlining
	  {
	    // Code size       1 (0x1)
	    .maxstack  8
	    IL_0000:  ret
	  } // end of method ShellViewModel::__Reactive_UpdateModel

	} // end of class Chefs.Presentation.ShellViewModel

Indeed, no `ShellViewModel::.ctor` method!

Fix this by *removing* `$(IsAotCompatible)`=true.

(It was the change to `$(IsAotCompatible)` within e838af94 which broke startup, *not* the changes to `$(PublishAot)`!)

GitHub Issue (If applicable): #

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type

What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR

- Bugfix
- Feature
- Code style update (formatting)
- Refactoring (no functional changes, no api changes)
- Build or CI related changes
- Documentation content changes
- Project automation
- Other... Please describe:

-->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences. Validate PR `Screenshots Compare Test Run` results.
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information

<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
