### PR TITLE
chore: Add devcontainer setup for Uno Chefs project

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,261 @@
+# .NET 9 SDK — matches the net9.0-* target frameworks in Chefs.csproj and the
+# Aspire 9.x AppHost. Do not bump to sdk:10.0 without also moving the repo's
+# TFMs; the net9.0-android/-ios workloads are not carried by the 10.0 image.
+FROM mcr.microsoft.com/dotnet/sdk:9.0
+
+ARG TZ
+ENV TZ="$TZ"
+
+ARG CLAUDE_CODE_VERSION=latest
+ARG COPILOT_CLI_VERSION=latest
+
+# ---------------------------------------------------------------------------
+# System packages
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  jq \
+  nano \
+  vim \
+  # DNS-based firewall (see init-firewall.sh)
+  dnsmasq \
+  iptables \
+  iproute2 \
+  dnsutils \
+  # Uno / Skia desktop dependencies
+  xvfb \
+  fluxbox \
+  libgtk-3-dev \
+  libwebkit2gtk-4.1-dev \
+  # SkiaSharp font resolution (LiveCharts + Mapsui render text via Skia)
+  libfontconfig1 \
+  # MediaPlayerElement on Linux/Skia is backed by LibVLC — Chefs plays recipe
+  # videos on the RecipeDetails page, so this is not optional here.
+  vlc \
+  libvlc-dev \
+  # File picker dialog support (xdg-desktop-portal chain + zenity fallback)
+  xdg-desktop-portal \
+  xdg-desktop-portal-gtk \
+  # xdg-open binary (Process.Start(url) on Linux)
+  xdg-utils \
+  zenity \
+  dbus \
+  dbus-user-session \
+  # Chefs.UITests drives WebAssembly through Selenium. Debian's chromium +
+  # chromium-driver are version-matched by the distro, which avoids the
+  # chromedriver/Chrome version skew the CI scripts work around by pinning
+  # npm chromedriver@127 + puppeteer.
+  chromium \
+  chromium-driver \
+  # SSH client (WSL host terminal)
+  openssh-client \
+  # Misc
+  curl \
+  wget \
+  ca-certificates \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# GitHub CLI (not in bookworm defaults)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Node.js 20 (Claude Code / Copilot CLI npm tooling, MCP servers via npx)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+  && apt-get install -y --no-install-recommends nodejs \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# git-delta (better diffs)
+# ---------------------------------------------------------------------------
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget -q "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# ---------------------------------------------------------------------------
+# Non-root user: developer (uid 1000)
+# Container is the security boundary, not in-container privileges.
+# ---------------------------------------------------------------------------
+ARG USERNAME=developer
+RUN existing_user=$(getent passwd 1000 | cut -d: -f1 || true) && \
+  if [ -n "$existing_user" ] && [ "$existing_user" != "${USERNAME}" ]; then \
+    usermod -l ${USERNAME} -d /home/${USERNAME} -m "$existing_user" && \
+    groupmod -n ${USERNAME} "$existing_user" 2>/dev/null || true; \
+  elif [ -z "$existing_user" ]; then \
+    useradd -m -s /bin/zsh -u 1000 ${USERNAME}; \
+  fi && \
+  chsh -s /bin/zsh ${USERNAME} && \
+  echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME} && \
+  chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# Persist shell history (env vars are set in the zsh-in-docker -a flag below)
+RUN mkdir -p /commandhistory && \
+  touch /commandhistory/.bash_history && \
+  chown -R ${USERNAME} /commandhistory
+
+ENV DEVCONTAINER=true
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+
+# Ensure non-root user owns /usr/local/share for npm global installs
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R ${USERNAME}:${USERNAME} /usr/local/share/npm-global
+
+# Create workspace and config directories
+RUN mkdir -p /uno-chefs /home/${USERNAME}/.claude /home/${USERNAME}/.copilot /home/${USERNAME}/.nuget && \
+  chown -R ${USERNAME}:${USERNAME} /uno-chefs /home/${USERNAME}/.claude /home/${USERNAME}/.copilot /home/${USERNAME}/.nuget
+
+WORKDIR /uno-chefs
+
+# ---------------------------------------------------------------------------
+# zsh + powerlevel10k
+# ---------------------------------------------------------------------------
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+USER ${USERNAME}
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh 2>/dev/null || true" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh 2>/dev/null || true" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+ENV SHELL=/bin/zsh
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+# npm global prefix — writable by non-root user
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# ---------------------------------------------------------------------------
+# Claude Code CLI (native installer — installs to ~/.local/bin/claude)
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://claude.ai/install.sh | bash -s -- ${CLAUDE_CODE_VERSION}
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+# ---------------------------------------------------------------------------
+# GitHub Copilot CLI (installs to ~/.local/bin/copilot)
+# Drop this layer (and the `copilot` aliases in post-start.sh, the
+# github.copilot* VS Code extensions, and the githubcopilot.com /
+# certificate-revocation entries in init-firewall.sh) if the team
+# standardises on a single agent CLI.
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://gh.io/copilot-install | bash -s -- ${COPILOT_CLI_VERSION}
+
+# ---------------------------------------------------------------------------
+# Microsoft Build of OpenJDK 21 — required by the Android SDK tooling chain
+# (sdkmanager, aapt2, d8) for `-f net9.0-android` builds. Installed manually
+# because uno-check does not provision a JDK on Linux.
+# ---------------------------------------------------------------------------
+USER root
+RUN . /etc/os-release && \
+  if [ "$ID" = "ubuntu" ]; then \
+    MS_REPO_PATH="ubuntu/${VERSION_ID}"; \
+  else \
+    MS_REPO_PATH="debian/${VERSION_ID%%.*}"; \
+  fi && \
+  wget -qO /tmp/packages-microsoft-prod.deb \
+    "https://packages.microsoft.com/config/${MS_REPO_PATH}/packages-microsoft-prod.deb" && \
+  dpkg -i /tmp/packages-microsoft-prod.deb && \
+  rm /tmp/packages-microsoft-prod.deb && \
+  apt-get update && apt-get install -y --no-install-recommends msopenjdk-21 && \
+  apt-get clean && rm -rf /var/lib/apt/lists/* && \
+  # msopenjdk-21 installs to /usr/lib/jvm/msopenjdk-21-<arch>. Resolve the real
+  # directory by walking from `javac` and pin an arch-agnostic symlink, because
+  # mcr.microsoft.com/dotnet/sdk:9.0 is multi-arch (this image may be built on
+  # Apple Silicon).
+  ln -sfn "$(dirname "$(dirname "$(readlink -f "$(command -v javac)")")")" \
+    /usr/lib/jvm/msopenjdk-21-current
+
+ENV JAVA_HOME=/usr/lib/jvm/msopenjdk-21-current
+ENV PATH=${JAVA_HOME}/bin:${PATH}
+
+# ---------------------------------------------------------------------------
+# .NET workloads — wasm-tools for net9.0-browserwasm, android for
+# net9.0-android. There is no emulator in this image (see .devcontainer/README);
+# `android` is here so the TFM compiles, not so it can be deployed.
+# ---------------------------------------------------------------------------
+RUN dotnet workload install wasm-tools android
+
+# ---------------------------------------------------------------------------
+# uno-check — provisions the Android SDK (cmdline-tools, build-tools, platforms)
+# into ANDROID_HOME and validates the workload set against the Uno.Sdk version
+# in global.json. Pinned to the same version the repo's GitHub CI uses
+# (.github/workflows/ci.yml) so the container and CI agree on what "valid"
+# means.
+#
+# androidemulator is skipped deliberately: this container has no /dev/kvm, so a
+# provisioned emulator + system image would be ~2GB of unusable download.
+# openjdk is skipped because uno-check does not handle the JDK on Linux (it is
+# installed above). `|| true` because uno-check exits non-zero for advisory
+# findings that must not fail the image build.
+# ---------------------------------------------------------------------------
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV PATH=${ANDROID_HOME}/platform-tools:${ANDROID_HOME}/cmdline-tools/latest/bin:${PATH}
+
+USER ${USERNAME}
+ENV PATH="${PATH}:/home/${USERNAME}/.dotnet/tools"
+RUN dotnet tool install --global uno.check --version 1.28.3
+USER root
+RUN mkdir -p ${ANDROID_HOME} && chown -R ${USERNAME}:${USERNAME} ${ANDROID_HOME} && \
+  uno-check -v --ci --non-interactive --fix \
+    --skip xcode --skip gtk3 --skip vswin --skip vswinworkloads --skip unosdk \
+    --skip dotnetnewunotemplates --skip vsmac --skip openjdk --skip androidemulator \
+    --tfm net9.0-desktop --tfm net9.0-browserwasm --tfm net9.0-android \
+    || true
+RUN chown -R ${USERNAME}:${USERNAME} ${ANDROID_HOME}
+
+# ---------------------------------------------------------------------------
+# Chefs.UITests (Browser platform) — Uno.UITest.Selenium resolves the driver
+# from a *directory* and the browser from a *binary path*. Debian installs
+# chromedriver at /usr/bin/chromedriver, so the driver directory is /usr/bin.
+# UNO_UITEST_PLATFORM / UNO_UITEST_TARGETURI stay unset: they are per-run
+# choices, see .devcontainer/README.md.
+# ---------------------------------------------------------------------------
+ENV UNO_UITEST_DRIVERPATH_CHROME=/usr/bin
+ENV UNO_UITEST_CHROME_BINARY_PATH=/usr/bin/chromium
+
+# ---------------------------------------------------------------------------
+# Neutralise VS Code git-credential forwarding
+# dpkg-divert moves the real binary to /usr/bin/git.distrib so that even
+# direct /usr/bin/git calls go through the wrapper.
+# ---------------------------------------------------------------------------
+RUN dpkg-divert --rename --add /usr/bin/git && \
+  printf '#!/bin/sh\nunset GIT_ASKPASS VSCODE_GIT_ASKPASS_MAIN VSCODE_GIT_ASKPASS_NODE VSCODE_GIT_IPC_HANDLE SSH_AUTH_SOCK\nexec /usr/bin/git.distrib -c credential.helper= "$@"\n' \
+  > /usr/bin/git && \
+  chmod +x /usr/bin/git
+
+# ---------------------------------------------------------------------------
+# Helper scripts
+# ---------------------------------------------------------------------------
+COPY init-firewall.sh /usr/local/bin/
+COPY ssh-wsl-host.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/ssh-wsl-host.sh && \
+  echo "${USERNAME} ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/${USERNAME}-firewall && \
+  chmod 0440 /etc/sudoers.d/${USERNAME}-firewall
+
+# ---------------------------------------------------------------------------
+# Disable Claude Code adaptive thinking
+# ---------------------------------------------------------------------------
+ENV CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1
+
+USER ${USERNAME}

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,139 @@
+# Uno Chefs dev container
+
+A Linux dev container for working on Uno Chefs: builds and runs the **WebAssembly**
+and **Desktop (Skia)** heads, compiles the **Android** head, runs **Chefs.Api**, and
+orchestrates the lot through an **Aspire** AppHost.
+
+> **Host requirement: Linux or WSL2.** The container bind-mounts `/tmp/.X11-unix`
+> and `$HOME/.local/share/Uno Platform` from the host, and `$HOME` is unset on
+> Windows-native Docker. Run VS Code from inside your WSL distro (`code .` in the
+> repo folder on the WSL side), not from Windows.
+
+## What's inside
+
+| | |
+|---|---|
+| Base | `mcr.microsoft.com/dotnet/sdk:9.0` — matches the repo's `net9.0-*` TFMs |
+| Workloads | `wasm-tools`, `android` (+ Microsoft OpenJDK 21, Android SDK via `uno-check`) |
+| Uno desktop deps | GTK3, WebKit2GTK, LibVLC (`MediaPlayerElement`), fontconfig (SkiaSharp), Xvfb |
+| UI tests | Debian `chromium` + `chromium-driver`, version-matched by the distro |
+| Agents | Claude Code, GitHub Copilot CLI, `uno` + `microsoft-learn` MCP servers |
+| Network | dnsmasq DNS allowlist (`init-firewall.sh`) |
+
+## First run
+
+1. From your WSL distro: `code /path/to/uno.chefs`
+2. **Dev Containers: Reopen in Container**
+
+`initializeCommand` runs `initialize-host.sh` on the WSL host to generate the
+`~/.ssh/uno-chefs-devcontainer-ed25519` keypair used by the *WSL Host* terminal
+profile. `postStartCommand` then runs `post-start.sh` inside the container
+(firewall, D-Bus, MCP registration, VS Code extension pre-install), and VS Code
+waits for it before activating the workspace.
+
+Optional host environment variables, read at container start:
+
+| Variable | Effect |
+|---|---|
+| `GH_TOKEN_READONLY` | Registers the GitHub MCP server. **Rejected if it carries any write scope** — use a read-only classic PAT. |
+| `DISPLAY` | Where the Desktop head renders. Defaults to `:0`. |
+| `TZ` | Container timezone. Defaults to `America/Los_Angeles`. |
+
+## Running things
+
+```bash
+# Everything: Chefs.Api + dashboard, with both client heads one click away
+dotnet run --project Chefs.AppHost          # dashboard at http://localhost:18888
+
+# Just the API
+dotnet run --project Chefs.Api              # http://localhost:5116, Swagger at /swagger
+
+# Client heads directly (mock data — the default)
+dotnet run --project Chefs -f net9.0-desktop
+dotnet run --project Chefs -f net9.0-browserwasm
+```
+
+Ports 5116, 18888, 51480 and 5000 are forwarded to the host.
+
+### The Aspire AppHost
+
+`Chefs.AppHost` registers three resources:
+
+- **`chefs-api`** — starts automatically, pinned to **port 5116**. That pin is
+  load-bearing: `Chefs/App.xaml.host.cs` hardcodes `http://localhost:5116` as the
+  Kiota client's base address, so a random Aspire port would leave every non-mock
+  build unable to connect.
+- **`chefs-wasm`** and **`chefs-desktop`** — registered but **explicit-start**, so
+  they sit "Stopped" in the dashboard until you click Start. Both are built with
+  `-p:UseMocks=false` so they talk to `chefs-api` instead of the bundled JSON.
+
+Mocking is a *compile-time* switch (`UseMocks` defines `USE_MOCKS`, which swaps
+`MockHttpMessageHandler` into the Kiota client), so switching between mock and
+live data is a rebuild — which is exactly what clicking Start does.
+
+There are **no container resources**, so this needs neither Docker-in-Docker nor
+`--privileged`. DCP logs a `Could not harvest all abandoned containers` warning at
+startup when no Docker daemon is present; it is harmless.
+
+### WebAssembly UI tests
+
+`chromium` and `chromium-driver` are installed and `UNO_UITEST_DRIVERPATH_CHROME`
+/ `UNO_UITEST_CHROME_BINARY_PATH` are already set. The per-run variables are not:
+
+```bash
+dotnet publish Chefs/Chefs.csproj -c Release \
+  -p:TargetFrameworkOverride=net9.0-browserwasm \
+  -p:IsUiAutomationMappingEnabled=True
+
+dotnet tool install -g dotnet-serve
+dotnet serve -p 5000 -d Chefs/bin/Release/net9.0-browserwasm/publish/wwwroot/ &
+
+UNO_UITEST_PLATFORM=Browser \
+UNO_UITEST_TARGETURI=http://localhost:5000 \
+  dotnet test Chefs.UITests/Chefs.UITests.csproj
+```
+
+`Chefs.UITests/TestBase.cs` runs Chrome **headed** under `#if DEBUG`; use
+`-c Release` for the test project, or expect it to need a display.
+
+## What this container deliberately does not do
+
+- **No Android emulator.** No `/dev/kvm`, no `--privileged`, no emulator system
+  images. `-f net9.0-android` compiles; deploying needs a device or emulator on
+  the host — use the *WSL Host* terminal profile to reach it.
+- **No iOS or Windows heads.** `net9.0-ios` needs macOS + Xcode;
+  `net9.0-windows10.0.19041` needs Windows. Same escape hatch.
+- **No Docker.** Nothing in this repo's Aspire graph needs it.
+
+## The DNS allowlist
+
+`init-firewall.sh` points `/etc/resolv.conf` at a local dnsmasq that only resolves
+an allowlist (NuGet, GitHub, Uno, Microsoft, Anthropic, npm, Android SDK CDNs).
+Everything else is `REFUSED`. This is a DNS-layer filter, not an IP-layer
+firewall — direct-IP egress is not blocked. Loopback is untouched, so Aspire and
+the dev servers are unaffected.
+
+Both agent CLIs are aliased into unattended mode (`claude
+--dangerously-skip-permissions`, `copilot --autopilot --allow-all`); the allowlist
+is what makes that a contained decision rather than an open one.
+
+**A new dependency host is a firewall change.** Symptom: `NU1301`, `ENOTFOUND`, or
+a hung restore. Add a `server=/<domain>/${UPSTREAM_DNS}` line and rebuild.
+
+## Trimming this down
+
+Each of these is self-contained if you want it gone:
+
+- **Copilot CLI** — the `gh.io/copilot-install` layer in `Dockerfile`, the
+  `copilot` aliases and Copilot MCP block in `post-start.sh`, the `github.copilot*`
+  extensions in `devcontainer.json`, and the `githubcopilot.com` /
+  certificate-revocation entries in `init-firewall.sh`.
+- **WSL host terminal** — `ssh-wsl-host.sh`, `initialize-host.sh`, the
+  `initializeCommand`, the SSH key mount, and the *WSL Host* terminal profile.
+  Requires an sshd on the WSL host listening on port 2222; without it the profile
+  simply fails to connect and nothing else is affected.
+- **Firewall** — `init-firewall.sh`, its `sudo` line in `post-start.sh`, the
+  `NET_ADMIN`/`NET_RAW` caps, and the `dnsmasq`/`iptables`/`dnsutils` packages.
+- **Android** — the JDK layer, `android` in `dotnet workload install`, the
+  `uno-check` Android SDK provisioning, and the `dl.google.com` /
+  `developer.android.com` / `maven.google.com` allowlist entries.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,107 @@
+{
+  // Linux / WSL host only — Windows-native Docker hosts are not supported
+  // (the X11 and Uno Platform mounts rely on $HOME, which is unset on Windows).
+  "name": "Uno Chefs — ${localWorkspaceFolderBasename}",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "TZ": "${localEnv:TZ:America/Los_Angeles}",
+      "CLAUDE_CODE_VERSION": "latest",
+      "COPILOT_CLI_VERSION": "latest",
+      "GIT_DELTA_VERSION": "0.18.2",
+      "ZSH_IN_DOCKER_VERSION": "1.2.0"
+    }
+  },
+  "runArgs": [
+    // Required by init-firewall.sh (dnsmasq bind + resolv.conf rewrite).
+    "--cap-add=NET_ADMIN",
+    "--cap-add=NET_RAW",
+    // Chromium (Chefs.UITests on the Browser platform) crashes with the
+    // default 64MB /dev/shm.
+    "--shm-size=4g"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "github.copilot",
+        "github.copilot-chat",
+        "unoplatform.vscode",
+        "ms-dotnettools.csdevkit",
+        "ms-dotnettools.vscode-dotnet-runtime",
+        "eamodio.gitlens"
+      ],
+      // Mirrors .vscode/settings.json so the container matches a host checkout,
+      // plus container-only terminal wiring.
+      "settings": {
+        "explorer.fileNesting.enabled": true,
+        "explorer.fileNesting.expand": false,
+        "explorer.fileNesting.patterns": {
+          "*.xaml": "$(capture).xaml.cs"
+        },
+        "files.associations": {
+          "global.json": "jsonc"
+        },
+        "unoplatform.ignoreCheck": true,
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "terminal.integrated.profiles.linux": {
+          "bash": {
+            "path": "bash",
+            "icon": "terminal-bash"
+          },
+          "zsh": {
+            "path": "zsh"
+          },
+          "WSL Host": {
+            "path": "/usr/local/bin/ssh-wsl-host.sh",
+            "icon": "vm",
+            "color": "terminal.ansiYellow",
+            "overrideName": true
+          }
+        }
+      }
+    }
+  },
+  "remoteUser": "developer",
+  "mounts": [
+    "source=unochefs-claude-config-${devcontainerId},target=/home/developer/.claude,type=volume",
+    "source=unochefs-copilot-config-${devcontainerId},target=/home/developer/.copilot,type=volume",
+    "source=unochefs-commandhistory-${devcontainerId},target=/commandhistory,type=volume",
+    // Shared across checkouts (no devcontainerId suffix): the package cache is a
+    // read-mostly download cache, not per-workspace state.
+    "source=unochefs-nuget-packages,target=/home/developer/.nuget/packages,type=volume",
+    // X11 socket so `dotnet run -f net9.0-desktop` renders on the WSL host's
+    // X server instead of needing Xvfb.
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
+    // Uno Platform credentials (licenses.bin / user.json) from the host, copied
+    // into place by post-start.sh. Optional — only needed for Hot Design.
+    "source=${localEnv:HOME}/.local/share/Uno Platform,target=/tmp/uno-platform-host,type=bind,readonly",
+    "source=${localEnv:HOME}/.ssh/uno-chefs-devcontainer-ed25519,target=/etc/devcontainer-ssh/id_ed25519,type=bind,readonly"
+  ],
+  "containerEnv": {
+    "DEVCONTAINER": "true",
+    "DOTNET_CLI_TELEMETRY_OPTOUT": "1",
+    "DISPLAY": "${localEnv:DISPLAY::0}",
+    "CLAUDE_CONFIG_DIR": "/home/developer/.claude",
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "WSL_HOST_WORKSPACE": "${localWorkspaceFolder}",
+    "WSL_HOST_USER": "${localEnv:USER}",
+    "GH_TOKEN": "${localEnv:GH_TOKEN_READONLY}"
+  },
+  // 5116  — Chefs.Api (pinned; App.xaml.host.cs hardcodes http://localhost:5116)
+  // 18888 — Aspire dashboard
+  // 51480 — Chefs WebAssembly dev server ("Chefs (WebAssembly)" launch profile)
+  // 5000  — dotnet-serve target for Chefs.UITests on the Browser platform
+  "forwardPorts": [5116, 18888, 51480, 5000],
+  "portsAttributes": {
+    "5116": { "label": "Chefs.Api" },
+    "18888": { "label": "Aspire dashboard" },
+    "51480": { "label": "Chefs (WebAssembly)" },
+    "5000": { "label": "UI test host" }
+  },
+  "initializeCommand": "mkdir -p \"${HOME}/.local/share/Uno Platform\" && bash \"${localWorkspaceFolder}/.devcontainer/initialize-host.sh\"",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/uno-chefs,type=bind,consistency=delegated",
+  "workspaceFolder": "/uno-chefs",
+  "postStartCommand": "bash /uno-chefs/.devcontainer/post-start.sh",
+  "waitFor": "postStartCommand"
+}

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+# ==========================================================================
+# init-firewall.sh — DNS allowlist filter for the dev container
+#
+# Uses dnsmasq as a local DNS proxy that only resolves allowed domain
+# patterns. Unmatched domains get REFUSED.
+#
+# NOTE: This is a DNS-layer filter, not an IP-layer firewall. Direct-IP
+# egress is not blocked. Full iptables egress rules are impractical here
+# because the allowed services (NuGet, Azure CDN, GitHub, etc.) resolve
+# to large, dynamic IP ranges. The DNS allowlist is sufficient to prevent
+# accidental or automated access to unauthorized services.
+#
+# Loopback is unaffected, so Aspire (dashboard, Chefs.Api on :5116, the WASM
+# dev server) works regardless of what is listed below.
+# ==========================================================================
+set -euo pipefail
+IFS=$'\n\t'
+
+DNSMASQ_LISTEN="127.0.0.53"
+
+# --------------------------------------------------------------------------
+# 1. Upstream DNS for allowed domains
+#    Priority: $UPSTREAM_DNS env var > first nameserver in /etc/resolv.conf > 8.8.8.8
+# --------------------------------------------------------------------------
+if [ -z "${UPSTREAM_DNS:-}" ]; then
+  UPSTREAM_DNS=$(grep -m1 '^nameserver' /etc/resolv.conf | awk '{print $2}' || true)
+  # Skip loopback (would point back at ourselves after resolv.conf rewrite)
+  if [ -z "$UPSTREAM_DNS" ] || echo "$UPSTREAM_DNS" | grep -qE '^127\.' || [ "$UPSTREAM_DNS" = "::1" ]; then
+    UPSTREAM_DNS="8.8.8.8"
+  fi
+fi
+echo "Upstream DNS: ${UPSTREAM_DNS}"
+
+# --------------------------------------------------------------------------
+# 2. Configure dnsmasq as allowlist DNS proxy
+# --------------------------------------------------------------------------
+mkdir -p /etc/dnsmasq.d
+
+cat > /etc/dnsmasq.d/allowlist.conf << EOF
+# Listen on local address only
+listen-address=${DNSMASQ_LISTEN}
+bind-interfaces
+port=53
+
+# Don't read /etc/resolv.conf or poll for changes
+no-resolv
+no-poll
+
+# =====================================================
+# ALLOWED DOMAIN PATTERNS
+# Each server= line forwards that domain + all subdomains
+# to the upstream DNS. Unmatched domains get REFUSED.
+# =====================================================
+
+# GitHub (git, gh CLI, PR workflows, raw content)
+server=/github.com/${UPSTREAM_DNS}
+server=/githubusercontent.com/${UPSTREAM_DNS}
+
+# GitHub Copilot CLI / editor endpoints
+server=/githubcopilot.com/${UPSTREAM_DNS}
+server=/api.business.githubcopilot.com/${UPSTREAM_DNS}
+server=/exp-tas.com/${UPSTREAM_DNS}
+server=/ghe.com/${UPSTREAM_DNS}
+
+# Certificate revocation/OCSP endpoints used by Copilot TLS chains
+server=/digicert.com/${UPSTREAM_DNS}
+server=/symantec.com/${UPSTREAM_DNS}
+server=/symcb.com/${UPSTREAM_DNS}
+server=/symcd.com/${UPSTREAM_DNS}
+server=/geotrust.com/${UPSTREAM_DNS}
+server=/thawte.com/${UPSTREAM_DNS}
+server=/verisign.com/${UPSTREAM_DNS}
+server=/globalsign.com/${UPSTREAM_DNS}
+server=/ssl.com/${UPSTREAM_DNS}
+server=/identrust.com/${UPSTREAM_DNS}
+server=/sectigo.com/${UPSTREAM_DNS}
+server=/usertrust.com/${UPSTREAM_DNS}
+
+# npm (Claude Code / Copilot CLI updates, npx-hosted MCP servers)
+server=/npmjs.org/${UPSTREAM_DNS}
+server=/npmjs.com/${UPSTREAM_DNS}
+
+# Anthropic (API, feature flags)
+server=/anthropic.com/${UPSTREAM_DNS}
+server=/claude.ai/${UPSTREAM_DNS}
+server=/claude.com/${UPSTREAM_DNS}
+
+# Error reporting & feature flags
+server=/sentry.io/${UPSTREAM_DNS}
+server=/statsig.com/${UPSTREAM_DNS}
+
+# VS Code (marketplace queries, updates)
+server=/visualstudio.com/${UPSTREAM_DNS}
+# Microsoft download CDN — download.visualstudio.microsoft.com hosts the
+# Xamarin / Android manifest feeds that the Android workload resolves via
+# aka.ms/AndroidManifestFeed/*. Different apex from `visualstudio.com` above
+# (download.visualstudio.MICROSOFT.com), so the prior entry doesn't cover it.
+server=/visualstudio.microsoft.com/${UPSTREAM_DNS}
+# VS Code Marketplace extension CDN — VSIX downloads resolve to
+# <publisher>.gallery.vsassets.io and <publisher>.gallerycdn.vsassets.io.
+# Without this, VS Code's first attempt to auto-install devcontainer
+# extensions fails with ENOTFOUND and the recommendation prompt fires for
+# unoplatform.vscode before the retry succeeds.
+server=/vsassets.io/${UPSTREAM_DNS}
+# VS Code Server CDN — used by the remote agent for marketplace queries
+# (main.vscode-cdn.net). Blocked → "getaddrinfo ENOTFOUND" in remoteagent.log.
+server=/vscode-cdn.net/${UPSTREAM_DNS}
+
+# Microsoft connectivity probes used by ms-dotnettools.vscode-dotnet-runtime
+# and aka.ms short-URL redirects used by .NET installer scripts.
+server=/www.microsoft.com/${UPSTREAM_DNS}
+
+# NuGet — the only package source in nuget.config, and where Aspire's
+# dashboard + orchestration (DCP) binaries come from on first AppHost run.
+server=/nuget.org/${UPSTREAM_DNS}
+
+# Azure CDN (.NET workloads, SDK downloads)
+server=/azureedge.net/${UPSTREAM_DNS}
+
+# .NET SDK & workloads
+server=/dotnet.microsoft.com/${UPSTREAM_DNS}
+
+# Microsoft Learn (MCP documentation server)
+server=/learn.microsoft.com/${UPSTREAM_DNS}
+
+# Microsoft package feed (OpenJDK, .NET repos — used by apt + uno-check)
+server=/packages.microsoft.com/${UPSTREAM_DNS}
+server=/aka.ms/${UPSTREAM_DNS}
+
+# Android SDK tooling — sdkmanager downloads build-tools/platforms from
+# dl.google.com, developer.android.com hosts the cmdline-tools redirects, and
+# maven.google.com serves the AndroidX artifacts a net9.0-android build resolves.
+server=/dl.google.com/${UPSTREAM_DNS}
+server=/developer.android.com/${UPSTREAM_DNS}
+server=/maven.google.com/${UPSTREAM_DNS}
+
+# Uno Platform — docs MCP server (mcp.platform.uno), Hot Design licensing,
+# and the platform.uno docs the Recipe Book cross-references.
+server=/platform.uno/${UPSTREAM_DNS}
+server=/unoplatform.net/${UPSTREAM_DNS}
+EOF
+
+# --------------------------------------------------------------------------
+# 3. Start dnsmasq
+# --------------------------------------------------------------------------
+echo "Starting dnsmasq DNS proxy..."
+dnsmasq --conf-file=/etc/dnsmasq.d/allowlist.conf --test 2>&1 && echo "  dnsmasq config OK"
+pkill dnsmasq 2>/dev/null || true
+sleep 0.2
+dnsmasq --conf-file=/etc/dnsmasq.d/allowlist.conf
+sleep 0.2
+if pgrep dnsmasq >/dev/null; then
+    echo "  dnsmasq running on ${DNSMASQ_LISTEN} (pid $(pgrep dnsmasq))"
+else
+    echo "ERROR: dnsmasq failed to start"
+    exit 1
+fi
+
+# --------------------------------------------------------------------------
+# 4. Point resolver at dnsmasq
+# --------------------------------------------------------------------------
+# Docker bind-mounts resolv.conf; back it up, then replace nameserver lines
+# while preserving search/options/sortlist directives.
+cp /etc/resolv.conf /etc/resolv.conf.docker.bak
+umount /etc/resolv.conf 2>/dev/null || true
+{ grep -v '^nameserver' /etc/resolv.conf.docker.bak || true; echo "nameserver ${DNSMASQ_LISTEN}"; } > /etc/resolv.conf
+
+# Verify resolv.conf was actually changed — fail hard if not
+if grep -q "${DNSMASQ_LISTEN}" /etc/resolv.conf; then
+    echo "  DNS resolver pointed to dnsmasq"
+else
+    echo "ERROR: resolv.conf was not updated — DNS filtering is NOT active"
+    echo "  Contents:"
+    cat /etc/resolv.conf
+    exit 1
+fi
+
+echo ""
+echo "========================================="
+echo " DNS allowlist filter configured"
+echo "========================================="
+
+# --------------------------------------------------------------------------
+# 5. Verification
+# --------------------------------------------------------------------------
+echo ""
+echo "Verifying..."
+
+# Should be BLOCKED (DNS refuses resolution)
+if curl --connect-timeout 5 https://example.com >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — was able to reach https://example.com"
+    exit 1
+else
+    echo "  PASS: https://example.com is blocked (DNS refused)"
+fi
+
+# Should be ALLOWED
+if ! curl --connect-timeout 5 https://api.github.com/zen >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — unable to reach https://api.github.com"
+    exit 1
+else
+    echo "  PASS: https://api.github.com is reachable"
+fi
+
+if ! curl --connect-timeout 5 https://api.nuget.org/v3/index.json >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — unable to reach https://api.nuget.org"
+    exit 1
+else
+    echo "  PASS: https://api.nuget.org is reachable"
+fi
+
+if ! curl --connect-timeout 5 https://api.githubcopilot.com/_ping >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — unable to reach https://api.githubcopilot.com"
+    exit 1
+else
+    echo "  PASS: https://api.githubcopilot.com is reachable"
+fi
+
+# Uno Platform docs MCP server — registered for Claude/Copilot by post-start.sh.
+if ! curl --connect-timeout 5 -o /dev/null https://platform.uno >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — unable to reach https://platform.uno"
+    exit 1
+else
+    echo "  PASS: https://platform.uno is reachable"
+fi
+
+# VS Code Marketplace extension CDN — required for devcontainer extensions to
+# auto-install on first try (otherwise the recommendation prompt fires).
+# The bare `gallery.vsassets.io` apex has no A record — only publisher-prefixed
+# subdomains do — so probe the actual host VS Code hits for the Uno extension.
+if ! getent hosts unoplatform.gallery.vsassets.io >/dev/null 2>&1; then
+    echo "ERROR: Firewall verification failed — DNS lookup for unoplatform.gallery.vsassets.io failed"
+    exit 1
+else
+    echo "  PASS: unoplatform.gallery.vsassets.io resolves"
+fi
+
+echo ""
+echo "Firewall verification passed"

--- a/.devcontainer/initialize-host.sh
+++ b/.devcontainer/initialize-host.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Runs on the WSL HOST (not inside the container) via initializeCommand,
+# before the devcontainer starts.
+#
+# Idempotently provisions a dedicated SSH keypair for the devcontainer's
+# ssh-wsl-host helper. The key is bind-mounted into the container at a
+# non-standard path (/etc/devcontainer-ssh/, not ~/.ssh/), so AI agents
+# running inside the container won't pick it up by default — only
+# ssh-wsl-host.sh references it explicitly with -i.
+#
+# Why a dedicated key (and not the user's regular id_*): we want to limit
+# blast radius. This key only authorizes connections from the devcontainer
+# back to the WSL host's internal sshd on port 2222.
+#
+# The host side of that sshd is not provisioned here — see
+# .devcontainer/README.md for the one-time host setup.
+set -euo pipefail
+
+KEY_NAME="uno-chefs-devcontainer-ed25519"
+KEY_PATH="${HOME}/.ssh/${KEY_NAME}"
+AUTHORIZED_KEYS="${HOME}/.ssh/authorized_keys"
+
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+
+if [[ ! -f "${KEY_PATH}" ]]; then
+  echo "initialize-host: generating dedicated SSH key for devcontainer ssh-wsl-host (${KEY_NAME})..."
+  ssh-keygen -t ed25519 -N "" -C "uno-chefs-devcontainer-host-shell" -f "${KEY_PATH}" >/dev/null
+fi
+chmod 600 "${KEY_PATH}"
+chmod 644 "${KEY_PATH}.pub"
+
+touch "${AUTHORIZED_KEYS}"
+chmod 600 "${AUTHORIZED_KEYS}"
+
+# Append the public key if its key material isn't already in authorized_keys.
+# Compare by key material (field 2 of the public key file, which is field 3 of
+# an authorized_keys line that carries leading options) so a re-added entry
+# with a different comment or different restrictions doesn't create a duplicate.
+#
+# The entry is prefixed with sshd authorized_keys options that limit what a
+# compromised devcontainer can do with this key:
+#   - restrict           : opt out of every permission (forwarding, command, etc.);
+#                          the more-specific options below re-enable only what we
+#                          need. Future-proofs us against new sshd capabilities.
+#   - pty                : re-enable PTY allocation (ssh-wsl-host runs `exec $SHELL -l`).
+# Forwarding (agent/X11/port/StreamLocal) and `command=` overrides stay denied
+# by `restrict`. We cannot pin `from=` to a specific IP because the WSL eth0 /
+# docker0 IPs change on every WSL reboot.
+KEY_OPTIONS='restrict,pty'
+KEY_FIELD=$(awk '{print $2}' "${KEY_PATH}.pub")
+KEY_LINE="${KEY_OPTIONS} $(cat "${KEY_PATH}.pub")"
+
+# An existing entry matches if its key material (the ssh-ed25519 base64 blob)
+# equals ours, regardless of leading options or trailing comment.
+already_present=0
+if [[ -s "${AUTHORIZED_KEYS}" ]]; then
+  while IFS= read -r line; do
+    # Strip leading options (everything up to and including the first space
+    # before "ssh-" / "ecdsa-" / etc.) then take field 2 = the key material.
+    material=$(awk '{ for (i=1;i<=NF;i++) if ($i ~ /^(ssh|ecdsa|sk)-/) { print $(i+1); exit } }' <<< "$line")
+    if [[ "$material" == "$KEY_FIELD" ]]; then
+      already_present=1
+      break
+    fi
+  done < "${AUTHORIZED_KEYS}"
+fi
+
+if (( already_present == 0 )); then
+  echo "initialize-host: adding restricted devcontainer public key to ${AUTHORIZED_KEYS}"
+  # Ensure the existing file ends with a newline before we append; otherwise our
+  # new entry would be concatenated onto the previous line, corrupting both
+  # entries and locking the devcontainer key out.
+  if [[ -s "${AUTHORIZED_KEYS}" ]] && [[ "$(tail -c1 "${AUTHORIZED_KEYS}" | wc -l)" -eq 0 ]]; then
+    printf '\n' >> "${AUTHORIZED_KEYS}"
+  fi
+  printf '%s\n' "${KEY_LINE}" >> "${AUTHORIZED_KEYS}"
+fi

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKSPACE="/uno-chefs"
+
+sudo /usr/local/bin/init-firewall.sh
+
+# The Docker named volume mounted at ~/.nuget/packages is created with root
+# ownership when the volume is first populated (before the developer user
+# exists in the container). After a WSL/Docker restart, ownership can also
+# revert to root. Either case prevents `dotnet restore` from extracting
+# packages and surfaces as `error MSB4236: The SDK 'Uno.Sdk' specified could
+# not be found.` Re-asserting ownership on every container start fixes it.
+sudo chown -R developer:developer "$HOME/.nuget/packages"
+
+# ---------------------------------------------------------------------------
+# Uno Platform credentials (Hot Design sign-in)
+#
+# The host's ~/.local/share/Uno Platform is bind-mounted read-only at
+# /tmp/uno-platform-host; copy the files into the container-local path the
+# Uno tooling actually reads. Chefs builds and runs fine without these — they
+# only matter for Hot Design.
+# ---------------------------------------------------------------------------
+mkdir -p "$HOME/.local/share/Uno Platform"
+if [ -d /tmp/uno-platform-host ]; then
+  find /tmp/uno-platform-host -maxdepth 1 -type f -exec cp {} "$HOME/.local/share/Uno Platform/" \;
+else
+  echo "Note: /tmp/uno-platform-host not found — skipping Uno Platform credential copy"
+fi
+
+dotnet dev-certs https --trust || true
+
+# ---------------------------------------------------------------------------
+# D-Bus session + xdg-desktop-portal (file picker dialogs on Linux/GTK)
+#
+# Uno's FileSavePicker/FileOpenPicker on the Skia GTK backend delegates to
+# xdg-desktop-portal, which requires a running D-Bus session. The host's
+# DBUS_SESSION_BUS_ADDRESS is not forwarded because the host socket isn't
+# mounted into the container — we start our own session bus here and pin
+# the address in shell rc files so new terminals inherit it.
+# ---------------------------------------------------------------------------
+DBUS_RUNTIME_DIR="/run/user/$(id -u)"
+DBUS_SOCKET="${DBUS_RUNTIME_DIR}/bus"
+
+sudo mkdir -p "$DBUS_RUNTIME_DIR"
+sudo chown "$(id -u):$(id -g)" "$DBUS_RUNTIME_DIR"
+chmod 700 "$DBUS_RUNTIME_DIR"
+
+if [ ! -S "$DBUS_SOCKET" ] || ! dbus-send \
+    --address="unix:path=${DBUS_SOCKET}" \
+    --dest=org.freedesktop.DBus \
+    --type=method_call \
+    /org/freedesktop/DBus \
+    org.freedesktop.DBus.ListNames &>/dev/null; then
+  rm -f "$DBUS_SOCKET"
+  dbus-daemon --session \
+    --address="unix:path=${DBUS_SOCKET}" \
+    --nopidfile \
+    --fork 2>/dev/null || true
+fi
+
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${DBUS_SOCKET}"
+export XDG_RUNTIME_DIR="$DBUS_RUNTIME_DIR"
+# xdg-desktop-portal picks the backend based on XDG_CURRENT_DESKTOP.
+export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:-GNOME}"
+
+# Persist for future shells (aliased terminals, VS Code tasks, etc.)
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+  [ -f "$rc" ] || continue
+  # Drop previous snippet so updates propagate on container rebuild.
+  sed -i '/# devcontainer: dbus session bus/,/# end devcontainer: dbus session bus/d' "$rc"
+  cat >> "$rc" <<'DBUSRC'
+
+# devcontainer: dbus session bus
+_dbus_socket="/run/user/$(id -u)/bus"
+if [ ! -S "$_dbus_socket" ] || ! dbus-send --address="unix:path=$_dbus_socket" \
+    --dest=org.freedesktop.DBus --type=method_call \
+    /org/freedesktop/DBus org.freedesktop.DBus.ListNames &>/dev/null; then
+  rm -f "$_dbus_socket"
+  dbus-daemon --session --address="unix:path=$_dbus_socket" --nopidfile --fork 2>/dev/null || true
+fi
+export DBUS_SESSION_BUS_ADDRESS="unix:path=$_dbus_socket"
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:-GNOME}"
+unset _dbus_socket
+# end devcontainer: dbus session bus
+DBUSRC
+done
+
+printf 'claude --dangerously-skip-permissions\n' >> "$HOME/.bash_history"
+printf 'copilot --autopilot --allow-all\n' >> "$HOME/.bash_history"
+
+# Alias so bare `claude` always starts in bypass-permissions mode (safe in devcontainer)
+# and disables adaptive thinking (CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1 is scoped to the command).
+# Note: CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING is set as a container-wide ENV in the
+# Dockerfile so the VS Code Claude Code extension inherits it too (the alias scope
+# only covers the `claude` CLI).
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+  if [ -f "$rc" ]; then
+    # Drop any previous `alias claude=` line so env-var/flag changes propagate on container restart.
+    sed -i '/^alias claude=/d' "$rc"
+    printf '\nalias claude="CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1 claude --dangerously-skip-permissions"\n' >> "$rc"
+  fi
+done
+
+# Alias so bare `copilot` runs in full autopilot mode (safe in devcontainer)
+for rc in "$HOME/.bashrc" "$HOME/.zshrc"; do
+  if [ -f "$rc" ] && ! grep -q 'alias copilot=' "$rc"; then
+    printf '\nalias copilot="copilot --autopilot --allow-all"\n' >> "$rc"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# GitHub MCP: read-only token validation + registration
+# ---------------------------------------------------------------------------
+if [ -n "${GH_TOKEN:-}" ]; then
+  echo "Validating GitHub token is read-only..."
+
+  # First, verify the token is actually valid
+  AUTH_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" \
+    -H "Authorization: token ${GH_TOKEN}" \
+    https://api.github.com/user 2>/dev/null || echo "000")
+
+  # Define write scopes that MUST NOT be present
+  WRITE_SCOPES="repo,public_repo,delete_repo,gist,workflow,write:org,admin:org,write:public_key,admin:public_key,write:repo_hook,admin:repo_hook,admin:org_hook,write:packages,write:gpg_key,admin:gpg_key,write:discussion,admin:enterprise"
+
+  TOKEN_REJECTED=false
+  if [ "$AUTH_STATUS" != "200" ]; then
+    echo "ERROR: GitHub token is invalid or unauthorized (HTTP ${AUTH_STATUS})." >&2
+    TOKEN_REJECTED=true
+  else
+    # Fetch token scopes from the API response headers (classic PATs)
+    SCOPES_HEADER=$(curl -sS -f -H "Authorization: token ${GH_TOKEN}" \
+      -I https://api.github.com/user 2>/dev/null \
+      | grep -i '^x-oauth-scopes:' | cut -d: -f2- | tr -d '[:space:]') || true
+
+    if [ -n "$SCOPES_HEADER" ]; then
+      # Classic PAT — check each write scope
+      IFS=',' read -ra BLOCKED <<< "$WRITE_SCOPES"
+      for scope in "${BLOCKED[@]}"; do
+        scope=$(echo "$scope" | xargs)  # trim whitespace
+        if echo ",$SCOPES_HEADER," | grep -qi ",$scope,"; then
+          echo "ERROR: GitHub token has write scope '$scope'. Only read-only tokens are allowed in the devcontainer." >&2
+          TOKEN_REJECTED=true
+          break
+        fi
+      done
+    else
+      # Fine-grained PAT — no X-OAuth-Scopes header is returned.
+      # Probe a write endpoint with invalid payload: 403 = no write access (good),
+      # 422 = has write access but bad payload (rejected).
+      WRITE_TEST=$(curl -sS -o /dev/null -w "%{http_code}" \
+        -H "Authorization: token ${GH_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -X POST https://api.github.com/user/repos \
+        -d '{"name":""}' 2>/dev/null) || true
+
+      if [ "$WRITE_TEST" = "422" ] || [ "$WRITE_TEST" = "201" ]; then
+        echo "ERROR: GitHub token has write permissions (repo create returned HTTP $WRITE_TEST). Only read-only tokens are allowed in the devcontainer." >&2
+        TOKEN_REJECTED=true
+      fi
+      # 403 or 404 = no write access, which is what we want
+    fi
+  fi
+
+  if [ "$TOKEN_REJECTED" = true ]; then
+    echo "GitHub MCP will NOT be registered. Please use a classic PAT with only read scopes." >&2
+    unset GH_TOKEN
+  else
+    echo "GitHub token validated — no write scopes detected."
+
+    # Register GitHub MCP for Claude Code
+    # The server reads GITHUB_PERSONAL_ACCESS_TOKEN; map from GH_TOKEN.
+    # NOTE: -e must come AFTER the server name — the flag is variadic and
+    # consumes all subsequent args until `--` if placed before the name.
+    claude mcp remove github || true
+    claude mcp add --scope user --transport stdio \
+      github -e "GITHUB_PERSONAL_ACCESS_TOKEN=${GH_TOKEN}" \
+      -- npx -y @modelcontextprotocol/server-github 2>/dev/null || true
+    echo "Claude GitHub MCP registered."
+  fi
+else
+  echo "Note: GH_TOKEN not set — GitHub MCP will not be registered. Set GH_TOKEN_READONLY in your WSL environment to enable it."
+fi
+
+# ---------------------------------------------------------------------------
+# Documentation MCP servers
+#
+# `uno`            — Uno Platform docs (the Recipe Book under doc/ is published
+#                    into this same docs site, so it is the authoritative source
+#                    for anything Chefs demonstrates).
+# `microsoft-learn`— .NET / ASP.NET Core / Aspire reference.
+#
+# studio.live also registers a `uno-app` stdio server via `dotnet dnx`; that is
+# a .NET 10 SDK command and this container is on the .NET 9 SDK (matching the
+# repo's net9.0-* TFMs), so it is deliberately omitted.
+# ---------------------------------------------------------------------------
+echo "Registering documentation MCP servers for Claude: uno, microsoft-learn."
+
+claude mcp remove uno || true
+claude mcp add --scope user --transport http uno https://mcp.platform.uno/v1 || true
+claude mcp remove microsoft-learn || true
+claude mcp add --scope user --transport http microsoft-learn https://learn.microsoft.com/api/mcp || true
+
+echo "Claude MCP registration complete. Verify with: claude mcp list"
+
+# ---------------------------------------------------------------------------
+# Copilot CLI: MCP servers
+# ---------------------------------------------------------------------------
+COPILOT_DIR="$HOME/.copilot"
+mkdir -p "$COPILOT_DIR"
+
+COPILOT_MCP_CONFIG="$COPILOT_DIR/mcp-config.json"
+
+# Build MCP servers JSON — include GitHub MCP only if GH_TOKEN survived validation
+if [ -n "${GH_TOKEN:-}" ]; then
+  MCP_SERVERS=$(jq -n \
+    --arg gh_token "$GH_TOKEN" \
+    '{
+      "mcpServers": {
+        "uno": { "type": "http", "url": "https://mcp.platform.uno/v1" },
+        "microsoft-learn": { "type": "http", "url": "https://learn.microsoft.com/api/mcp" },
+        "github": {
+          "type": "stdio",
+          "command": "npx",
+          "args": ["-y", "@modelcontextprotocol/server-github"],
+          "env": { "GITHUB_PERSONAL_ACCESS_TOKEN": $gh_token }
+        }
+      }
+    }')
+  echo "Copilot MCPs: uno, microsoft-learn, github"
+else
+  MCP_SERVERS='{
+    "mcpServers": {
+      "uno": { "type": "http", "url": "https://mcp.platform.uno/v1" },
+      "microsoft-learn": { "type": "http", "url": "https://learn.microsoft.com/api/mcp" }
+    }
+  }'
+  echo "Copilot MCPs: uno, microsoft-learn (GitHub MCP skipped — no GH_TOKEN)"
+fi
+
+if [ -f "$COPILOT_MCP_CONFIG" ]; then
+  if jq empty "$COPILOT_MCP_CONFIG" 2>/dev/null; then
+    # Deep-merge new servers into existing config (preserves user-added servers)
+    echo "$MCP_SERVERS" | jq -s '.[0] * .[1]' "$COPILOT_MCP_CONFIG" - > "${COPILOT_MCP_CONFIG}.tmp" \
+      && mv "${COPILOT_MCP_CONFIG}.tmp" "$COPILOT_MCP_CONFIG"
+  else
+    echo "Warning: $COPILOT_MCP_CONFIG contains invalid JSON. Backing up to ${COPILOT_MCP_CONFIG}.bak" >&2
+    cp "$COPILOT_MCP_CONFIG" "${COPILOT_MCP_CONFIG}.bak"
+    echo "$MCP_SERVERS" | jq . > "$COPILOT_MCP_CONFIG"
+  fi
+else
+  echo "$MCP_SERVERS" | jq . > "$COPILOT_MCP_CONFIG"
+fi
+
+echo "Copilot MCP registration complete. Config written to $COPILOT_MCP_CONFIG."
+
+# ---------------------------------------------------------------------------
+# Claude Code status line
+# ---------------------------------------------------------------------------
+cat > "$HOME/.claude/statusline.sh" << 'STATUSLINE'
+#!/bin/bash
+export LANG=C.UTF-8
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model.display_name')
+DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+PCT=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | cut -d. -f1)
+DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
+
+CYAN='\033[36m'; GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; RESET='\033[0m'
+
+# Pick bar color based on context usage
+if [ "$PCT" -ge 90 ]; then BAR_COLOR="$RED"
+elif [ "$PCT" -ge 70 ]; then BAR_COLOR="$YELLOW"
+else BAR_COLOR="$GREEN"; fi
+
+FILLED=$((PCT / 10)); EMPTY=$((10 - FILLED))
+BAR=$(printf "%${FILLED}s" | tr ' ' '=')$(printf "%${EMPTY}s" | tr ' ' '-')
+
+MINS=$((DURATION_MS / 60000)); SECS=$(((DURATION_MS % 60000) / 1000))
+
+BRANCH=""
+git rev-parse --git-dir > /dev/null 2>&1 && BRANCH=" | 🌿 $(git branch --show-current 2>/dev/null)"
+
+echo -e "${CYAN}[$MODEL]${RESET} 📁 ${DIR##*/}$BRANCH"
+COST_FMT=$(printf '$%.2f' "$COST")
+echo -e "${BAR_COLOR}${BAR}${RESET} ${PCT}% | ${YELLOW}${COST_FMT}${RESET} | ⏱️ ${MINS}m ${SECS}s"
+STATUSLINE
+chmod +x "$HOME/.claude/statusline.sh"
+
+# Deep-merge statusLine config into Claude settings (preserves existing nested keys)
+CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+STATUSLINE_CFG='{"skipDangerousModePermissionPrompt":true,"permissions":{"defaultMode":"bypassPermissions"},"statusLine":{"type":"command","command":"~/.claude/statusline.sh","padding":2}}'
+if [ -f "$CLAUDE_SETTINGS" ]; then
+  if jq empty "$CLAUDE_SETTINGS" 2>/dev/null; then
+    jq ". * $STATUSLINE_CFG" "$CLAUDE_SETTINGS" > "${CLAUDE_SETTINGS}.tmp" && mv "${CLAUDE_SETTINGS}.tmp" "$CLAUDE_SETTINGS"
+  else
+    echo "Warning: $CLAUDE_SETTINGS contains invalid JSON. Backing up to ${CLAUDE_SETTINGS}.bak" >&2
+    cp "$CLAUDE_SETTINGS" "${CLAUDE_SETTINGS}.bak"
+    echo "$STATUSLINE_CFG" | jq . > "$CLAUDE_SETTINGS"
+  fi
+else
+  echo "$STATUSLINE_CFG" | jq . > "$CLAUDE_SETTINGS"
+fi
+
+# ---------------------------------------------------------------------------
+# VS Code extensions — synchronous install before the workspace activates.
+#
+# Why here (postStartCommand) instead of postAttachCommand: waitFor in
+# devcontainer.json is set to "postStartCommand", so VS Code blocks workspace
+# activation until this script returns. Installing extensions at postAttach
+# races with VS Code's workspace-recommendation check, which fires the
+# "Do you want to install the recommended 'Uno Platform' extension..." prompt
+# on every rebuild because unoplatform.vscode isn't yet present when the
+# check runs. By installing synchronously here, every extension declared in
+# customizations.vscode.extensions is on disk before the workspace activates,
+# and the recommendation check passes silently.
+#
+# devcontainer.json is parsed (rather than hardcoding the list) so this stays
+# in sync if the extensions array changes.
+# ---------------------------------------------------------------------------
+# `code` is provided by VS Code Server, which the Dev Containers extension
+# installs shortly after the container starts — it may not be on PATH the
+# moment this script begins. Poll briefly before giving up.
+for _ in $(seq 1 30); do
+  if command -v code >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! command -v code >/dev/null 2>&1; then
+  echo "Note: VS Code CLI 'code' not available after 30s; skipping extension pre-install."
+  echo "      VS Code's own auto-install from devcontainer.json will still run, but the"
+  echo "      workspace-recommendation prompt may fire on first attach."
+else
+  devcontainer_json="${WORKSPACE}/.devcontainer/devcontainer.json"
+
+  mapfile -t required_extensions < <(
+    awk '
+      /"extensions"[[:space:]]*:[[:space:]]*\[/ { in_extensions = 1; next }
+      in_extensions && /\]/ { in_extensions = 0; next }
+      in_extensions {
+        if ($0 ~ /"/) {
+          line = $0
+          sub(/^[^"]*"/, "", line)
+          sub(/".*$/, "", line)
+          if (line != "") {
+            print line
+          }
+        }
+      }
+    ' "$devcontainer_json"
+  )
+
+  if [ "${#required_extensions[@]}" -eq 0 ]; then
+    echo "Note: no extensions declared in $devcontainer_json"
+  else
+    installed_extensions="$(code --list-extensions 2>/dev/null || true)"
+    for extension_id in "${required_extensions[@]}"; do
+      if ! grep -Fxiq "$extension_id" <<<"$installed_extensions"; then
+        echo "Installing VS Code extension: $extension_id"
+        code --install-extension "$extension_id" --force \
+          || echo "Warning: failed to install extension $extension_id"
+      fi
+    done
+  fi
+
+  # ---------------------------------------------------------------------
+  # Workaround for unoplatform.vscode not activating after auto-install.
+  #
+  # When VS Code's Dev Containers extension installs unoplatform.vscode
+  # via customizations.vscode.extensions, the install completes and the
+  # extension appears in `code --list-extensions`, but it never activates
+  # (no _doActivateExtension log entry, no globalStorage created), even
+  # after its dependencies (ms-dotnettools.csharp, csdevkit) are active
+  # and the workspaceContains pattern matches. Symptom: extension shows
+  # grayed out in the Extensions view, no commands in the palette.
+  #
+  # The auto-install path writes `isApplicationScoped: true` into the
+  # extension metadata. Reinstalling via `code --install-extension`
+  # produces working state (isMachineScoped: true instead) and triggers
+  # proper activation. Other auto-installed extensions also have
+  # isApplicationScoped: true but activate normally — the interaction
+  # is specific to this extension.
+  #
+  # Detect the bad state and force a clean reinstall.
+  extensions_json="/home/developer/.vscode-server/extensions/extensions.json"
+  if [ -f "$extensions_json" ] && command -v jq >/dev/null 2>&1; then
+    # Detection is best-effort: if VS Code is mid-rewrite of extensions.json
+    # (truncated/invalid JSON) jq exits non-zero and `set -e` would abort the
+    # whole post-start. Swallow the failure and treat the state as unknown.
+    uno_bad_state=$(jq -r '
+      .[] | select(.identifier.id == "unoplatform.vscode")
+          | .metadata.isApplicationScoped // false
+    ' "$extensions_json" 2>/dev/null || echo "")
+    if [ "$uno_bad_state" = "true" ]; then
+      echo "Detected unoplatform.vscode installed via Dev Containers auto-install"
+      echo "(isApplicationScoped:true blocks activation). Force-reinstalling..."
+      code --uninstall-extension unoplatform.vscode 2>/dev/null || true
+      code --install-extension unoplatform.vscode --force 2>/dev/null \
+        || echo "Warning: force-reinstall of unoplatform.vscode failed"
+    fi
+  fi
+fi
+
+echo ""
+echo "==============================================================="
+echo " Uno Chefs devcontainer ready"
+echo "==============================================================="
+echo "  Aspire (API + apps):  dotnet run --project Chefs.AppHost"
+echo "  API only:             dotnet run --project Chefs.Api"
+echo "  Desktop:              dotnet run --project Chefs -f net9.0-desktop"
+echo "  WebAssembly:          dotnet run --project Chefs -f net9.0-browserwasm"
+echo ""
+echo "  Remember -p:TargetFrameworkOverride=<tfm> for one-off builds; see CLAUDE.md."
+echo "==============================================================="

--- a/.devcontainer/ssh-wsl-host.sh
+++ b/.devcontainer/ssh-wsl-host.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Opens an SSH session to the WSL host via the internal-only sshd (port 2222).
+# sshd is bound to the WSL eth0 IP — not exposed to Windows host or LAN.
+#
+# Useful from inside this container for the things it deliberately cannot do:
+# running the Windows-only net9.0-windows10.0.19041 build, launching an Android
+# emulator (no /dev/kvm here), or driving iOS from a paired Mac.
+#
+# Auth uses a dedicated ed25519 key bind-mounted at /etc/devcontainer-ssh/
+# (NOT ~/.ssh/). The non-standard path keeps the key out of reach of any
+# agent that naively shells out to `ssh user@host` — only this wrapper
+# references it explicitly via -i. The keypair is provisioned on the WSL
+# host by .devcontainer/initialize-host.sh.
+KEY_PATH="/etc/devcontainer-ssh/id_ed25519"
+
+if [[ ! -r "$KEY_PATH" ]]; then
+  echo "ssh-wsl-host: key not found at $KEY_PATH" >&2
+  echo "  Restart the devcontainer so initializeCommand (initialize-host.sh)" >&2
+  echo "  can provision the keypair on the WSL host." >&2
+  exit 1
+fi
+
+GATEWAY="$(ip route show default | awk '{print $3}')"
+
+# WSL_HOST_USER is injected via containerEnv from the host's $USER.
+# Fall back to a prompt only if the env var isn't set.
+WSL_USER="${WSL_HOST_USER:-}"
+if [[ -z "$WSL_USER" ]]; then
+  read -rp "WSL username: " WSL_USER
+fi
+
+# Set a dark-red background to visually distinguish the WSL host terminal.
+# OSC 11 sets the terminal background color; restored on exit via trap.
+printf '\e]11;#2e1a1a\a'
+trap 'printf "\e]11;reset\a"' EXIT
+
+# Change to the workspace folder on the WSL host (same bind-mount source)
+REMOTE_CD=""
+if [[ -n "${WSL_HOST_WORKSPACE:-}" ]]; then
+  REMOTE_CD="cd '${WSL_HOST_WORKSPACE}' 2>/dev/null; "
+fi
+
+# IdentitiesOnly + IdentityAgent=none + PreferredAuthentications=publickey
+# guarantee this command can only authenticate with the bind-mounted key —
+# no ssh-agent forwarding, no password fallback, no opportunistic key reuse.
+exec ssh \
+  -o StrictHostKeyChecking=accept-new \
+  -o UserKnownHostsFile="$HOME/.ssh/wsl-host-known_hosts" \
+  -o IdentitiesOnly=yes \
+  -o IdentityAgent=none \
+  -o PreferredAuthentications=publickey \
+  -o ConnectTimeout=5 \
+  -i "$KEY_PATH" \
+  -t \
+  -p 2222 \
+  "${WSL_USER}@${GATEWAY}" \
+  "${REMOTE_CD}exec \$SHELL -l"

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 ###############################################################################
 * text=auto
 *.sh text eol=lf
+
+###############################################################################
+# Docker chokes on CRLF line continuations, and the dev container image is
+# built from a WSL checkout where `text=auto` would otherwise apply the host's
+# native endings.
+###############################################################################
+Dockerfile text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Uno Chefs is a cross-platform recipe app that serves as Uno Platform's flagship real-world sample. Nearly every feature exists to demonstrate an Uno capability, and most are documented as a "recipe" under `doc/` that gets published into the Uno Platform docs site — changing a feature usually means updating its recipe too.
+
+Four projects in `Chefs.sln`:
+
+- `Chefs/` — the Uno single-project app (Android, iOS, Windows/WinAppSDK, Desktop, WebAssembly)
+- `Chefs.Api/` — ASP.NET Core Web API backing the app, serving the shared `AppData/*.json`
+- `Chefs.AppHost/` — Aspire orchestration for local dev (API + client heads)
+- `Chefs.UITests/` — NUnit + Uno.UITest UI automation (there are no unit tests)
+
+No CI job builds `Chefs.sln`; every pipeline targets `Chefs/Chefs.csproj` directly.
+
+## Build & run
+
+The Uno.Sdk version is pinned in `global.json`. Packages use Central Package Management (`Directory.Packages.props`), but most dependencies come from `<UnoFeatures>` in `Chefs/Chefs.csproj` rather than explicit `PackageReference`s — add capabilities there first.
+
+### Always constrain the target framework
+
+`Chefs.csproj` cross-targets five TFMs. Passing `-f`/`-p:TargetFramework` alone still *restores* all of them, forcing every workload to be installed. Pass `TargetFrameworkOverride` as a global property instead:
+
+```bash
+dotnet build Chefs/Chefs.csproj -p:TargetFrameworkOverride=net9.0-desktop
+dotnet run --project Chefs -f net9.0-desktop
+```
+
+Valid values: `net9.0-desktop`, `net9.0-browserwasm`, `net9.0-windows10.0.19041`, `net9.0-android`, `net9.0-ios`.
+
+For IDE work, copy `crosstargeting_override.props.sample` to `crosstargeting_override.props` (imported by `Directory.Build.props`) and uncomment only the platforms you need.
+
+### Mock data vs. live API
+
+`UseMocks` defaults to `true`, which defines `USE_MOCKS` and swaps `MockHttpMessageHandler` into the Kiota client so the app reads `AppData/*.json` locally. **Mocking is a compile-time switch, so moving to live data is a rebuild, not a config change.** To run against the real API:
+
+```bash
+dotnet run --project Chefs.Api      # http://localhost:5116, Swagger UI at /swagger
+dotnet build Chefs/Chefs.csproj -p:TargetFrameworkOverride=net9.0-desktop -p:UseMocks=false
+```
+
+The endpoint URL is hardcoded in `App.xaml.host.cs` — which is why anything launching the API must pin port 5116.
+
+### Aspire (`Chefs.AppHost`)
+
+`dotnet run --project Chefs.AppHost` starts `Chefs.Api` on the pinned port plus the dashboard on `http://localhost:18888`, and registers `chefs-wasm` / `chefs-desktop` as **explicit-start** resources — they stay stopped until clicked, then build with `-p:UseMocks=false` against the live API.
+
+Aspire is 9.x (not 13.x): 13.x AppHosts target `net10.0` and this repo is on .NET 9. The `Aspire.AppHost.Sdk` version lives in `Chefs.AppHost.csproj` because MSBuild SDK references are outside Central Package Management, while `Aspire.Hosting.AppHost` is in `Directory.Packages.props` — bump both together.
+
+There are no container resources, so no Docker is required; DCP's `Could not harvest all abandoned containers` startup warning is harmless. `Chefs.Api` enables a permissive CORS policy **in Development only**, because the WebAssembly head calls it cross-origin (`:51480` → `:5116`).
+
+### Rendering variants
+
+CI builds each platform twice, once with `-p:UseSkiaRendering=true` and once with native rendering. If a bug is rendering-specific, reproduce with the matching flag.
+
+### Dev container
+
+`.devcontainer/` provides a Linux container for WASM + Desktop + Android-build work — see `.devcontainer/README.md`. **WSL2/Linux hosts only** (it bind-mounts `$HOME` paths and the X11 socket). It deliberately has no Android emulator, no iOS/Windows heads and no Docker; the *WSL Host* terminal profile is the escape hatch to the host for those.
+
+Network egress inside the container goes through a dnsmasq **DNS allowlist** (`init-firewall.sh`). A new dependency host means a new `server=/<domain>/` line — the symptom is `NU1301`/`ENOTFOUND`/a hung restore, not an obvious network error.
+
+### Formatting (verified in CI, so run before pushing)
+
+```bash
+dotnet format Chefs.sln
+xstyler --recursive --config xaml-styler.json --directory Chefs
+```
+
+CI runs `xstyler ... --passive` to verify XAML, and commit messages must follow Conventional Commits.
+
+## Tests
+
+`Chefs.UITests` drives the *built* app — a published WASM site served over HTTP and driven by Selenium, or a deployed Android/iOS app. It needs the app built with `-p:IsUiAutomationMappingEnabled=True`, which also defines `USE_UITESTS` and enables the `App.GetCurrentPage()` backdoor the tests assert against. Debug builds set this automatically.
+
+Configuration comes entirely from `UNO_UITEST_*` environment variables — `UNO_UITEST_PLATFORM` (`Browser`/`Android`/`iOS`), `UNO_UITEST_TARGETURI`, `UNO_UITEST_SCREENSHOT_PATH`, etc. See `build/scripts/*-uitest-run.sh` for the full set CI uses; those scripts are the fastest way to reproduce a CI test run locally.
+
+```bash
+dotnet test Chefs.UITests/Chefs.UITests.csproj --filter "Name~When_SmokeTest"
+```
+
+Test classes are named `Given_<Subject>`, tests `When_<Scenario>`, derived from `TestBase` and marked `[AutoRetry]`. `TestBase` screenshots on teardown and dumps browser logs.
+
+## Architecture
+
+Data flows one direction through four layers inside `Chefs/`: `Client/` → `Business/` → `Presentation/` → `Views/`.
+
+- **`Client/`** — Kiota-generated API client (`ChefsApiClient`, `Client/Api/**`, `Client/Models/*Data.cs`). Generated code, marked `<auto-generated/>`; regenerate rather than hand-edit. `Client/Mock/` holds the offline handler, which dispatches by URL path to per-entity endpoint classes that load JSON from `ms-appx:///AppData/`.
+- **`Business/`** — domain records (`Recipe`, `Cookbook`, `User`, …) that wrap the `*Data` DTOs through an `internal` constructor and convert back with `ToData()`, plus the services (`IRecipeService`, `ICookbookService`, `IUserService`, `INotificationService`, `IShareService`), all registered as singletons.
+- **`Presentation/`** — MVUX models, one `public partial record <Name>Model` per page. Dependencies are constructor-injected; state is exposed as `IFeed`/`IState`/`IListFeed`/`IListState`; commands are plain `public async ValueTask Foo(CancellationToken ct)` methods that the MVUX source generator surfaces to XAML as bindable commands.
+- **`Views/`** — `<Name>Page.xaml` per model, plus `Controls/`, `Dialogs/`, `Flyouts/`, `Templates/`. Resource dictionaries live in `Styles/`, value converters in `Converters/`.
+
+### Composition root
+
+`Chefs/App.xaml.host.cs` wires everything: authentication, the Kiota client (and mock handler), logging, configuration sections, serialization, services, and `RegisterRoutes` — which declares every `ViewMap`/`DataViewMap` and the nested `RouteMap` tree. **Adding a page means adding a model, a page, and both registrations here.**
+
+### Cross-cutting patterns
+
+- **Messaging** — services publish `EntityMessage<T>` via `IMessenger` (`WeakReferenceMessenger`); models subscribe with `.Observe(_messenger, x => x.Id)`, so a change made on one page updates every other list holding that entity. This is why most list state is created with `.Observe(...)` rather than plain `ListFeed.Async`.
+- **Navigation** — routes are strings resolved against the `RouteMap` tree (e.g. `"/Main/-/Search"`), issued from XAML via `uen:Navigation.Request` or from a model via `_navigator.NavigateRouteAsync`. Address-bar updates are disabled and the launch URL is cleared at startup (deep-linking issue #738).
+- **Serialization** — all JSON goes through source-generated `JsonSerializerContext`s (`MockEndpointContext`, `AppConfigContext`). New mock payload types must be registered in `ConfigureSerialization`, or they work in Debug and fail under AOT/WASM trimming.
+- **Shared data** — root-level `AppData/*.json` feeds both apps: `Content` linked into `ms-appx:///AppData/` for `Chefs`, `EmbeddedResource` for `Chefs.Api`.
+
+### XAML conventions
+
+Prefixes used throughout: `utu:` Uno.Toolkit.UI, `uer:` Uno.Extensions.Reactive.UI (`FeedView`), `uen:` Uno.Extensions.Navigation.UI, `muxc:` Microsoft.UI.Xaml.Controls, `ut:` Uno.Themes. Platform-conditional markup uses the `mobile` / `not_mobile` XAML namespaces, resolved by the `IncludeXamlNamespaces`/`ExcludeXamlNamespaces` items in `Chefs.csproj`.
+
+`FEATURES.md` catalogues every control and helper the app uses, with a one-line rationale for each.
+
+## Code style
+
+`.editorconfig` is authoritative and enforced by `dotnet format` in CI. Notably: **tabs** in C# and XAML, file-scoped namespaces (warning), expression-bodied members when they fit on one line (warning), nullable and implicit usings enabled. `Chefs/GlobalUsings.cs` is large — check it before adding a `using`.
+
+## Documentation (`doc/`)
+
+The Recipe Book is one Markdown file per feature, each with DocFx `uid:` front matter and cross-referenced as `xref:Uno.Recipes.<Name>`. A new recipe must be listed in **both** `doc/RecipeBooksOverview.md` and `doc/toc.yml`. Recipes link to source using permalinked GitHub URLs (commit SHA plus line range), so moving code silently invalidates them.
+
+`doc/docs-setup-local.md` explains how to render the Recipe Book locally against a clone of the main Uno repo.

--- a/Chefs.Api/Program.cs
+++ b/Chefs.Api/Program.cs
@@ -1,6 +1,8 @@
 using Chefs.Api.Serialization;
 using Microsoft.OpenApi.Models;
 
+const string DevelopmentCorsPolicy = "DevelopmentCors";
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
@@ -11,6 +13,14 @@ builder.Services.AddControllers()
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c => c.SwaggerDoc("v1", new OpenApiInfo { Title = "Chefs API", Version = "v1" }));
 
+// The WebAssembly head calls this API from a different origin (the Uno dev
+// server on :51480, this API on :5116), so the browser preflights every
+// request. Development only — applied below alongside Swagger.
+builder.Services.AddCors(options => options.AddPolicy(DevelopmentCorsPolicy, policy => policy
+	.AllowAnyOrigin()
+	.AllowAnyHeader()
+	.AllowAnyMethod()));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -18,6 +28,7 @@ if (app.Environment.IsDevelopment())
 {
 	app.UseSwagger();
 	app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Chefs API V1"));
+	app.UseCors(DevelopmentCorsPolicy);
 }
 
 app.UseHttpsRedirection();

--- a/Chefs.Api/Serialization/TimeSpanConverter.cs
+++ b/Chefs.Api/Serialization/TimeSpanConverter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Serialization;
 
 namespace Chefs.Api.Serialization;
+
 public class TimeSpanObjectConverter : JsonConverter<TimeSpan>
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)

--- a/Chefs.AppHost/Chefs.AppHost.csproj
+++ b/Chefs.AppHost/Chefs.AppHost.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<!-- Aspire 9.x, not 13.x: 13.x AppHosts target net10.0 and this repo is on
+	     net9.0 (see global.json / Chefs.csproj). Version is declared here rather
+	     than in Directory.Packages.props because MSBuild SDK references are not
+	     covered by Central Package Management. -->
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.5.2" />
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<RootNamespace>Chefs.AppHost</RootNamespace>
+		<IsAspireHost>true</IsAspireHost>
+		<UserSecretsId>chefs-apphost-4d8f2c31-6b90-4a7e-9c15-2f8ab6d0e743</UserSecretsId>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Aspire.Hosting.AppHost" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Chefs.Api\Chefs.Api.csproj" IsAspireProjectResource="true" />
+	</ItemGroup>
+</Project>

--- a/Chefs.AppHost/Program.cs
+++ b/Chefs.AppHost/Program.cs
@@ -1,0 +1,86 @@
+// Aspire AppHost for Uno Chefs.
+//
+// `dotnet run --project Chefs.AppHost` brings up Chefs.Api and puts the Uno
+// client apps one click away in the dashboard, so the whole "app talking to the
+// real API" loop is a single command instead of two terminals plus a rebuild.
+//
+// Everything here is local-dev orchestration — there are no container resources,
+// which is why the devcontainer needs neither Docker-in-Docker nor --privileged.
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+// ─── Chefs.Api ────────────────────────────────────────────────────────────────
+// Port 5116 is pinned, not incidental: Chefs/App.xaml.host.cs hardcodes
+//   new EndpointOptions { Url = "http://localhost:5116" }
+// as the Kiota client base address. Without the pin Aspire allocates a fresh
+// proxy port per run and every non-mock client build silently fails to connect.
+// The value matches the "http" profile in Chefs.Api/Properties/launchSettings.json
+// so `dotnet run --project Chefs.Api` and the AppHost expose the same address.
+//
+// The health probe uses /api/Recipe/categories because the API has no dedicated
+// health endpoint and categories.json is by far the smallest embedded payload
+// (~1.4KB vs ~140KB for Recipes.json), so polling it is cheap.
+var api = builder.AddProject<Projects.Chefs_Api>("chefs-api")
+	.WithEndpoint("http", endpoint => endpoint.Port = 5116)
+	.WithHttpHealthCheck("/api/Recipe/categories", endpointName: "http");
+
+// ─── Uno client apps (registered always, started on demand) ───────────────────
+// WithExplicitStart keeps these "Stopped" until you click Start in the
+// dashboard: a cold Uno build is expensive and you rarely want both heads at
+// once, but having them listed means one AppHost session can drive either.
+//
+// Two MSBuild properties matter on every one of these:
+//
+//   TargetFrameworkOverride — Chefs.csproj cross-targets five TFMs and `-f`
+//     alone still restores all of them, which demands every workload be
+//     installed. The csproj collapses TargetFrameworks to this value.
+//
+//   UseMocks=false — mocking is a compile-time switch (it defines USE_MOCKS,
+//     which swaps MockHttpMessageHandler into the Kiota client). Running
+//     against chefs-api therefore requires a rebuild, not just a config change.
+
+// Browser-hosted, so its calls to http://localhost:5116 are cross-origin. The API
+// enables a permissive CORS policy in Development for exactly this reason (see
+// Chefs.Api/Program.cs) — without it every request fails preflight.
+builder.AddExecutable(
+		name: "chefs-wasm",
+		command: "dotnet",
+		workingDirectory: "..",
+		args:
+		[
+			"run",
+			"--project", "Chefs/Chefs.csproj",
+			"--framework", "net9.0-browserwasm",
+			"--property:TargetFrameworkOverride=net9.0-browserwasm",
+			"--property:UseMocks=false",
+			"--launch-profile", "Chefs (WebAssembly)",
+		])
+	// isProxied: false — the Uno WASM dev server owns this port via the
+	// "Chefs (WebAssembly)" launch profile (applicationUrl http://localhost:51480).
+	// Aspire only advertises the URL in the dashboard; proxying it would put a
+	// second listener in front of a port the dev server already binds.
+	.WithHttpEndpoint(port: 51480, name: "http", isProxied: false)
+	.WithExternalHttpEndpoints()
+	.WithExplicitStart()
+	.WaitFor(api);
+
+builder.AddExecutable(
+		name: "chefs-desktop",
+		command: "dotnet",
+		workingDirectory: "..",
+		args:
+		[
+			"run",
+			"--project", "Chefs/Chefs.csproj",
+			"--framework", "net9.0-desktop",
+			"--property:TargetFrameworkOverride=net9.0-desktop",
+			"--property:UseMocks=false",
+		])
+	// Skia desktop needs an X server. In the devcontainer DISPLAY is set
+	// container-wide and /tmp/.X11-unix is bind-mounted from the WSL host, so the
+	// child process inherits a working display. Outside a container this is
+	// simply whatever the developer's session already has.
+	.WithExplicitStart()
+	.WaitFor(api);
+
+builder.Build().Run();

--- a/Chefs.AppHost/Properties/launchSettings.json
+++ b/Chefs.AppHost/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    // Plain HTTP only. The devcontainer has no trusted ASP.NET dev cert, and
+    // ASPIRE_ALLOW_UNSECURED_TRANSPORT is what lets the dashboard + OTLP
+    // endpoint bind over http instead of refusing to start.
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:18888",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:18889",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/Chefs.sln
+++ b/Chefs.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chefs.Api", "Chefs.Api\Chef
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chefs.UITests", "Chefs.UITests\Chefs.UITests.csproj", "{4B78AF19-4DA3-4CB0-B502-6C33F54F5A2A}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chefs.AppHost", "Chefs.AppHost\Chefs.AppHost.csproj", "{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +125,34 @@ Global
 		{4B78AF19-4DA3-4CB0-B502-6C33F54F5A2A}.Release|x64.Build.0 = Release|Any CPU
 		{4B78AF19-4DA3-4CB0-B502-6C33F54F5A2A}.Release|x86.ActiveCfg = Release|Any CPU
 		{4B78AF19-4DA3-4CB0-B502-6C33F54F5A2A}.Release|x86.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|x64.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Debug|x86.Build.0 = Debug|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|ARM.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|ARM64.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|iPhone.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|x64.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|x64.Build.0 = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|x86.ActiveCfg = Release|Any CPU
+		{7C3E1B92-4A5D-4F81-9E62-0B8D4A1C6E37}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Aspire 9.x targets net9.0, matching this repo. The matching
+         Aspire.AppHost.Sdk version is declared in Chefs.AppHost.csproj —
+         MSBuild SDK references are outside Central Package Management, so the
+         two must be bumped together. -->
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.2" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Uno.WinUI" Version="2.0.0-rc4.5" />
     <PackageVersion Include="Mapsui.Uno.WinUI" Version="5.0.0" />

--- a/global.json
+++ b/global.json
@@ -6,4 +6,3 @@
     "allowPrerelease": false
   }
 }
-I

--- a/global.json
+++ b/global.json
@@ -6,3 +6,4 @@
     "allowPrerelease": false
   }
 }
+I


### PR DESCRIPTION
This pull request introduces a comprehensive Linux-based dev container setup for the Uno Chefs project, focused on supporting WebAssembly, Desktop (Skia), and Android development, as well as Aspire orchestration. It adds a new `.devcontainer` directory with a feature-rich `Dockerfile`, a detailed `README.md`, and a VS Code `devcontainer.json` configuration. The container is tailored for WSL2 or native Linux hosts and includes tooling, dependencies, and environment configuration for streamlined development and testing.

The most important changes are:

**Dev Container Environment and Tooling:**
* Added `.devcontainer/Dockerfile` to build a development container based on `mcr.microsoft.com/dotnet/sdk:9.0`, with all necessary dependencies for Uno Chefs development (e.g., .NET 9 workloads, Uno/Skia/GTK/WebKit2GTK/LibVLC, Android SDK, Chromium, Claude Code, Copilot CLI, Node.js, git-delta, zsh with powerlevel10k, and helper scripts).
* Created `.devcontainer/devcontainer.json` to define the VS Code dev container, including build args, mounts for configuration and X11, port forwarding, terminal profiles (including a WSL host SSH profile), and recommended extensions (Claude Code, Copilot, Uno Platform, .NET tools, GitLens).

**Documentation and Usage Instructions:**
* Added `.devcontainer/README.md` with detailed documentation on container capabilities, host requirements, first-run instructions, port usage, running/testing guidance, and explanations of included/excluded features (e.g., no Android emulator, no Docker-in-Docker, DNS allowlist firewall).

**Security and Network Configuration:**
* Integrated a DNS allowlist firewall using `dnsmasq` and helper scripts (`init-firewall.sh`), restricting external network access to approved domains for package restoration and agent CLIs.
* Ensured privileged container capabilities (`NET_ADMIN`, `NET_RAW`) for firewall setup, and provided instructions for trimming or customizing the setup if certain features are not needed. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R107) [[2]](diffhunk://#diff-0f9548cbce10dbdef0b86d783ed0727a4ac1061fc71cb549b5dbd400705c71fdR1-R139)

**Developer Experience Enhancements:**
* Configured persistent shell history, non-root `developer` user, and global npm install support; set up default environment variables for improved usability and reproducibility.
* Provided guidance and automation for host/container integration (e.g., SSH key setup for WSL host terminal, copying Uno Platform credentials, and post-start scripts for environment preparation). [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R1-R107) [[2]](diffhunk://#diff-0f9548cbce10dbdef0b86d783ed0727a4ac1061fc71cb549b5dbd400705c71fdR1-R139)